### PR TITLE
Add operators for online bayesian linear regression

### DIFF
--- a/src/Bonsai.ML.LinearSystems/BayesianLinearRegression.cs
+++ b/src/Bonsai.ML.LinearSystems/BayesianLinearRegression.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+using MathNet.Numerics.LinearAlgebra;
+
+namespace Bonsai.ML.LinearSystems
+{
+    /// <summary>
+    /// Represents an operator that performs bayesian linear regression on a sequence
+    /// of temporal observations.
+    /// </summary>
+    [Combinator]
+    [Description("Performs bayesian linear regression on a sequence of temporal observations.")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class BayesianLinearRegression
+    {
+        /// <summary>
+        /// Gets or sets the assumed fixed precision for the prior.
+        /// </summary>
+        [Description("The assumed fixed precision for the prior.")]
+        public double PriorPrecision { get; set; }
+
+        /// <summary>
+        /// Gets or sets the assumed fixed precision for the likelihood.
+        /// </summary>
+        [Description("The assumed fixed precision for the likelihood.")]
+        public double LikelihoodPrecision { get; set; }
+
+        /// <summary>
+        /// Gets or sets the initial mean estimate for the regression process.
+        /// </summary>
+        [TypeConverter(typeof(UnidimensionalArrayConverter))]
+        [Description("The initial mean estimate for the regression process.")]
+        public double[] M0 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the initial variance estimate for the regression process.
+        /// </summary>
+        [XmlIgnore]
+        [TypeConverter(typeof(MultidimensionalArrayConverter))]
+        [Description("The initial mean estimate for the regression process.")]
+        public double[,] S0 { get; set; }
+
+        /// <summary>
+        /// Gets or sets an XML representation of the image convolution kernel.
+        /// </summary>
+        [Browsable(false)]
+        [XmlElement(nameof(S0))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string S0Xml
+        {
+            get { return ArrayConvert.ToString(S0, CultureInfo.InvariantCulture); }
+            set { S0 = (double[,])ArrayConvert.ToArray(value, 2, typeof(double), CultureInfo.InvariantCulture); }
+        }
+
+        /// <summary>
+        /// Updates the posterior given an observation and precision parameters.
+        /// </summary>
+        /// <param name="mn">The prior estimated mean.</param>
+        /// <param name="Sn">The prior estimated variance.</param>
+        /// <param name="phi">The new observation vector.</param>
+        /// <param name="y">The temporal weighting for the observation vector.</param>
+        /// <param name="alpha">The precision of the prior.</param>
+        /// <param name="beta">The precision of the likelihood.</param>
+        /// <returns>The estimated posterior.</returns>
+        public static (Vector<double> mean, Matrix<double> cov) OnlineUpdate(Vector<double> mn, Matrix<double> Sn, Vector<double> phi, double y, double alpha, double beta)
+        {
+            Vector<double> aux1 = Sn.Multiply(phi);
+            double aux2 = 1.0 / (1.0 / beta + phi.ToRowMatrix().Multiply(Sn).Multiply(phi)[0]);
+
+            Matrix<double> Snp1 = Sn - aux2 * aux1.OuterProduct(aux1);
+            Vector<double> mnp1 = beta * y * Snp1.Multiply(phi) + mn - aux2 * phi.DotProduct(mn) * Sn.Multiply(phi);
+
+            return (mnp1, Snp1);
+        }
+
+        /// <summary>
+        /// Performs bayesian linear regression on a sequence of temporal observations.
+        /// </summary>
+        /// <param name="source">The sequence of temporal observations.</param>
+        /// <returns>
+        /// The sequence of estimated posterior distributions, updated for
+        /// each temporal observation.
+        /// </returns>
+        public IObservable<MultivariateGaussian> Process(IObservable<(double x, double t)> source)
+        {
+            return Observable.Defer(() =>
+            {
+                Vector<double> mn = Vector<double>.Build.DenseOfArray(M0);
+                Matrix<double> Sn = Matrix<double>.Build.DenseOfArray(S0);
+                double alpha = PriorPrecision;
+                double beta = LikelihoodPrecision;
+                return source.Select(observation =>
+                {
+                    double[] aux = new[] { 1, observation.x };
+                    Vector<double> phi = Vector<double>.Build.DenseOfArray(aux);
+                    (mn, Sn) = OnlineUpdate(mn, Sn, phi, observation.t, alpha, beta);
+                    return new MultivariateGaussian { Mean = mn, Covariance = Sn };
+                });
+            });
+        }
+    }
+}

--- a/src/Bonsai.ML.LinearSystems/Bonsai.ML.LinearSystems.csproj
+++ b/src/Bonsai.ML.LinearSystems/Bonsai.ML.LinearSystems.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>Bonsai - ML LinearSystems</Title>
+    <Description>A package for the Bonsai visual programming language.</Description>
+    <PackageTags>Bonsai Rx Bonsai.ML.LinearSystems</PackageTags>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bonsai.ML\Bonsai.ML.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Bonsai.ML.LinearSystems/MultivariateGaussian.cs
+++ b/src/Bonsai.ML.LinearSystems/MultivariateGaussian.cs
@@ -1,0 +1,20 @@
+﻿using MathNet.Numerics.LinearAlgebra;
+
+namespace Bonsai.ML.LinearSystems
+{
+    /// <summary>
+    /// Represents the result of a bayesian linear regression process.
+    /// </summary>
+    public class MultivariateGaussian
+    {
+        /// <summary>
+        /// The estimated mean.
+        /// </summary>
+        public Vector<double> Mean;
+
+        /// <summary>
+        /// The estimated variance.
+        /// </summary>
+        public Matrix<double> Covariance;
+    }
+}

--- a/src/Bonsai.ML.LinearSystems/Properties/launchSettings.json
+++ b/src/Bonsai.ML.LinearSystems/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Bonsai": {
+      "commandName": "Executable",
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/src/Bonsai.ML.sln
+++ b/src/Bonsai.ML.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.ML.LinearSystems", "Bonsai.ML.LinearSystems\Bonsai.ML.LinearSystems.csproj", "{6A8FF465-D26A-462B-BB14-D9EAB1F78728}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{E93576CA-18C0-44C7-B124-CC48FAF95F7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E93576CA-18C0-44C7-B124-CC48FAF95F7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E93576CA-18C0-44C7-B124-CC48FAF95F7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A8FF465-D26A-462B-BB14-D9EAB1F78728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A8FF465-D26A-462B-BB14-D9EAB1F78728}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A8FF465-D26A-462B-BB14-D9EAB1F78728}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A8FF465-D26A-462B-BB14-D9EAB1F78728}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds operators for online bayesian linear regression of multivariate normal distributions given sequences of sampled observations. It is based off early prototypes by @joacorapela for experimentation with reactive online learning and inference.