### PR TITLE
Linear regression subpackage added to linear dynamical systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The Bonsai.ML project is a collection of packages with reactive infrastructure f
 * Bonsai.ML - provides core functionality across all Bonsai.ML packages.
 * Bonsai.ML.LinearDynamicalSystems - package for performing inference of linear dynamical systems. Interfaces with the [lds_python](https://github.com/joacorapela/lds_python) package.
   - *Bonsai.ML.LinearDynamicalSystems.Kinematics* - subpackage included in the LinearDynamicalSystems package which supports using the Kalman Filter to infer kinematic data.
+  - *Bonsai.ML.LinearDynamicalSystems.LinearRegression* - subpackage included in the LinearDynamicalSystems package which supports using the Kalman Filter to perform Bayesian linear regression.
 * Bonsai.ML.Visualizers - provides a set of visualizers for dynamic graphing/plotting.
 
 > [!NOTE]

--- a/src/Bonsai.ML.LinearDynamicalSystems/Bonsai.ML.LinearDynamicalSystems.csproj
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Bonsai.ML.LinearDynamicalSystems.csproj
@@ -4,7 +4,7 @@
     <Description>A Bonsai package for implementing the Kalman Filter using python.</Description>
     <PackageTags>Bonsai Rx ML KalmanFilter LinearDynamicalSystems</PackageTags>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.8.1" />

--- a/src/Bonsai.ML.LinearDynamicalSystems/Bonsai.ML.LinearDynamicalSystems.csproj
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Bonsai.ML.LinearDynamicalSystems.csproj
@@ -4,7 +4,7 @@
     <Description>A Bonsai package for implementing the Kalman Filter using python.</Description>
     <PackageTags>Bonsai Rx ML KalmanFilter LinearDynamicalSystems</PackageTags>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.8.1" />

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateKFModel.bonsai
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateKFModel.bonsai
@@ -1,0 +1,121 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:p1="clr-namespace:Bonsai.ML.LinearDynamicalSystems;assembly=Bonsai.ML.LinearDynamicalSystems"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p2="clr-namespace:Bonsai.ML.LinearDynamicalSystems.LinearRegression;assembly=Bonsai.ML.LinearDynamicalSystems"
+                 xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" Category="ModelReference" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateModelReference">
+          <p1:Name>model</p1:Name>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>model</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Name</Selector>
+      </Expression>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="LikelihoodPrecisionCoef" />
+        <Property Name="PriorPrecisionCoef" />
+        <Property Name="Mn" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p2:KFModelParameters">
+          <p2:LikelihoodPrecisionCoef>25</p2:LikelihoodPrecisionCoef>
+          <p2:PriorPrecisionCoef>2</p2:PriorPrecisionCoef>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:ObserveOnGIL" />
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>{0} = KalmanFilterLinearRegression({1})</Format>
+        <Selector>it.Item1, it.Item2</Selector>
+      </Expression>
+      <Expression xsi:type="InputMapping">
+        <PropertyMappings>
+          <Property Name="Script" Selector="it" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>LDSModule</Name>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="Module" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:Exec">
+          <py:Script>model = KalmanFilterLinearRegression()</py:Script>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="InputMapping">
+        <PropertyMappings>
+          <Property Name="VariableName" Selector="it.Item2" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>LDSModule</Name>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="Module" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:Get">
+          <py:VariableName>model</py:VariableName>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p2:KFModelParameters">
+          <p2:LikelihoodPrecisionCoef>25</p2:LikelihoodPrecisionCoef>
+          <p2:PriorPrecisionCoef>2</p2:PriorPrecisionCoef>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="0" To="2" Label="Source2" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="7" Label="Source1" />
+      <Edge From="3" To="14" Label="Source2" />
+      <Edge From="4" To="6" Label="Source1" />
+      <Edge From="5" To="6" Label="Source2" />
+      <Edge From="6" To="7" Label="Source2" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="13" Label="Source1" />
+      <Edge From="11" To="12" Label="Source1" />
+      <Edge From="12" To="13" Label="Source2" />
+      <Edge From="13" To="14" Label="Source1" />
+      <Edge From="14" To="15" Label="Source1" />
+      <Edge From="15" To="18" Label="Source1" />
+      <Edge From="16" To="17" Label="Source1" />
+      <Edge From="17" To="18" Label="Source2" />
+      <Edge From="18" To="19" Label="Source1" />
+      <Edge From="19" To="20" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateKFModel.bonsai
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateKFModel.bonsai
@@ -1,19 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <WorkflowBuilder Version="2.8.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xmlns:p1="clr-namespace:Bonsai.ML.LinearDynamicalSystems;assembly=Bonsai.ML.LinearDynamicalSystems"
+                 xmlns:p1="clr-namespace:Bonsai.ML.LinearDynamicalSystems.LinearRegression;assembly=Bonsai.ML.LinearDynamicalSystems"
+                 xmlns:p2="clr-namespace:Bonsai.ML.LinearDynamicalSystems;assembly=Bonsai.ML.LinearDynamicalSystems"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
-                 xmlns:p2="clr-namespace:Bonsai.ML.LinearDynamicalSystems.LinearRegression;assembly=Bonsai.ML.LinearDynamicalSystems"
                  xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="LikelihoodPrecisionCoef" Category="Parameters" />
+        <Property Name="PriorPrecisionCoef" Category="Parameters" />
+        <Property Name="N_features" Category="Parameters" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="X" Category="ModelState" />
+        <Property Name="P" Category="ModelState" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:KFModelParameters">
+          <p1:LikelihoodPrecisionCoef>25</p1:LikelihoodPrecisionCoef>
+          <p1:PriorPrecisionCoef>2</p1:PriorPrecisionCoef>
+          <p1:N_features>2</p1:N_features>
+        </Combinator>
+      </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" Category="ModelReference" />
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="p1:CreateModelReference">
-          <p1:Name>model</p1:Name>
+        <Combinator xsi:type="p2:CreateModelReference">
+          <p2:Name>model</p2:Name>
         </Combinator>
       </Expression>
       <Expression xsi:type="rx:BehaviorSubject">
@@ -22,100 +41,72 @@
       <Expression xsi:type="MemberSelector">
         <Selector>Name</Selector>
       </Expression>
-      <Expression xsi:type="WorkflowInput">
-        <Name>Source1</Name>
-      </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="LikelihoodPrecisionCoef" />
-        <Property Name="PriorPrecisionCoef" />
-        <Property Name="Mn" />
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="p2:KFModelParameters">
-          <p2:LikelihoodPrecisionCoef>25</p2:LikelihoodPrecisionCoef>
-          <p2:PriorPrecisionCoef>2</p2:PriorPrecisionCoef>
-        </Combinator>
-      </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:Zip" />
       </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="py:ObserveOnGIL" />
+      <Expression xsi:type="rx:Sink">
+        <Name>InitModel</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="py:ObserveOnGIL" />
+            </Expression>
+            <Expression xsi:type="Format">
+              <Format>{0} = KalmanFilterLinearRegression({1})</Format>
+              <Selector>it.Item2, it.Item1</Selector>
+            </Expression>
+            <Expression xsi:type="InputMapping">
+              <PropertyMappings>
+                <Property Name="Script" Selector="it" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>LDSModule</Name>
+            </Expression>
+            <Expression xsi:type="PropertyMapping">
+              <PropertyMappings>
+                <Property Name="Module" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="py:Exec">
+                <py:Script>model = KalmanFilterLinearRegression(likelihood_precision_coef=25,prior_precision_coef=2,n_features=2,x=None,P=None)</py:Script>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+            <Edge From="3" To="6" Label="Source1" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="5" To="6" Label="Source2" />
+            <Edge From="6" To="7" Label="Source1" />
+          </Edges>
+        </Workflow>
       </Expression>
-      <Expression xsi:type="Format">
-        <Format>{0} = KalmanFilterLinearRegression({1})</Format>
-        <Selector>it.Item1, it.Item2</Selector>
-      </Expression>
-      <Expression xsi:type="InputMapping">
-        <PropertyMappings>
-          <Property Name="Script" Selector="it" />
-        </PropertyMappings>
-      </Expression>
-      <Expression xsi:type="SubscribeSubject">
-        <Name>LDSModule</Name>
-      </Expression>
-      <Expression xsi:type="PropertyMapping">
-        <PropertyMappings>
-          <Property Name="Module" />
-        </PropertyMappings>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="py:Exec">
-          <py:Script>model = KalmanFilterLinearRegression()</py:Script>
-        </Combinator>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="rx:Zip" />
-      </Expression>
-      <Expression xsi:type="InputMapping">
-        <PropertyMappings>
-          <Property Name="VariableName" Selector="it.Item2" />
-        </PropertyMappings>
-      </Expression>
-      <Expression xsi:type="SubscribeSubject">
-        <Name>LDSModule</Name>
-      </Expression>
-      <Expression xsi:type="PropertyMapping">
-        <PropertyMappings>
-          <Property Name="Module" />
-        </PropertyMappings>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="py:Get">
-          <py:VariableName>model</py:VariableName>
-        </Combinator>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="p2:KFModelParameters">
-          <p2:LikelihoodPrecisionCoef>25</p2:LikelihoodPrecisionCoef>
-          <p2:PriorPrecisionCoef>2</p2:PriorPrecisionCoef>
-        </Combinator>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Item1</Selector>
       </Expression>
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
-      <Edge From="0" To="1" Label="Source1" />
-      <Edge From="0" To="2" Label="Source2" />
-      <Edge From="1" To="2" Label="Source1" />
-      <Edge From="2" To="3" Label="Source1" />
-      <Edge From="3" To="7" Label="Source1" />
-      <Edge From="3" To="14" Label="Source2" />
-      <Edge From="4" To="6" Label="Source1" />
-      <Edge From="5" To="6" Label="Source2" />
-      <Edge From="6" To="7" Label="Source2" />
-      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="0" To="3" Label="Source1" />
+      <Edge From="1" To="3" Label="Source2" />
+      <Edge From="2" To="3" Label="Source3" />
+      <Edge From="3" To="8" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="4" To="6" Label="Source2" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
       <Edge From="8" To="9" Label="Source1" />
       <Edge From="9" To="10" Label="Source1" />
-      <Edge From="10" To="13" Label="Source1" />
-      <Edge From="11" To="12" Label="Source1" />
-      <Edge From="12" To="13" Label="Source2" />
-      <Edge From="13" To="14" Label="Source1" />
-      <Edge From="14" To="15" Label="Source1" />
-      <Edge From="15" To="18" Label="Source1" />
-      <Edge From="16" To="17" Label="Source1" />
-      <Edge From="17" To="18" Label="Source2" />
-      <Edge From="18" To="19" Label="Source1" />
-      <Edge From="19" To="20" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateKFModel.bonsai
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateKFModel.bonsai
@@ -14,7 +14,7 @@
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="LikelihoodPrecisionCoef" Category="Parameters" />
         <Property Name="PriorPrecisionCoef" Category="Parameters" />
-        <Property Name="N_features" Category="Parameters" />
+        <Property Name="NumFeatures" Category="Parameters" />
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="X" Category="ModelState" />
@@ -24,7 +24,7 @@
         <Combinator xsi:type="p1:KFModelParameters">
           <p1:LikelihoodPrecisionCoef>25</p1:LikelihoodPrecisionCoef>
           <p1:PriorPrecisionCoef>2</p1:PriorPrecisionCoef>
-          <p1:N_features>2</p1:N_features>
+          <p1:NumFeatures>2</p1:NumFeatures>
         </Combinator>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateKFModel.bonsai
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateKFModel.bonsai
@@ -12,8 +12,8 @@
         <Name>Source1</Name>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
-        <Property Name="LikelihoodPrecisionCoef" Category="Parameters" />
-        <Property Name="PriorPrecisionCoef" Category="Parameters" />
+        <Property Name="LikelihoodPrecisionCoefficient" Category="Parameters" />
+        <Property Name="PriorPrecisionCoefficient" Category="Parameters" />
         <Property Name="NumFeatures" Category="Parameters" />
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
@@ -22,8 +22,8 @@
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="p1:KFModelParameters">
-          <p1:LikelihoodPrecisionCoef>25</p1:LikelihoodPrecisionCoef>
-          <p1:PriorPrecisionCoef>2</p1:PriorPrecisionCoef>
+          <p1:LikelihoodPrecisionCoefficient>25</p1:LikelihoodPrecisionCoefficient>
+          <p1:PriorPrecisionCoefficient>2</p1:PriorPrecisionCoefficient>
           <p1:NumFeatures>2</p1:NumFeatures>
         </Combinator>
       </Expression>
@@ -73,7 +73,7 @@
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="py:Exec">
-                <py:Script>model = KalmanFilterLinearRegression(likelihood_precision_coef=25,prior_precision_coef=2,n_features=2,x=None,P=None)</py:Script>
+                <py:Script>model = KalmanFilterLinearRegression(likelihood_precision_coef=25, prior_precision_coef=2, n_features=2, x=None, P=None)</py:Script>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateMultivariatePDF.bonsai
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateMultivariatePDF.bonsai
@@ -29,6 +29,14 @@
       <Expression xsi:type="MemberSelector">
         <Selector>Item2</Selector>
       </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="X0" Category="GridParameters" />
+        <Property Name="X1" Category="GridParameters" />
+        <Property Name="Xsteps" Category="GridParameters" />
+        <Property Name="Y0" Category="GridParameters" />
+        <Property Name="Y1" Category="GridParameters" />
+        <Property Name="Ysteps" Category="GridParameters" />
+      </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="p2:GridParameters">
           <p2:X0>-1</p2:X0>
@@ -113,15 +121,16 @@
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="4" To="5" Label="Source2" />
       <Edge From="5" To="6" Label="Source1" />
-      <Edge From="6" To="8" Label="Source1" />
-      <Edge From="7" To="8" Label="Source2" />
-      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="6" To="9" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source2" />
       <Edge From="9" To="10" Label="Source1" />
-      <Edge From="10" To="13" Label="Source1" />
-      <Edge From="11" To="12" Label="Source1" />
-      <Edge From="12" To="13" Label="Source2" />
-      <Edge From="13" To="14" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="11" To="14" Label="Source1" />
+      <Edge From="12" To="13" Label="Source1" />
+      <Edge From="13" To="14" Label="Source2" />
       <Edge From="14" To="15" Label="Source1" />
+      <Edge From="15" To="16" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateMultivariatePDF.bonsai
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateMultivariatePDF.bonsai
@@ -4,6 +4,7 @@
                  xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
                  xmlns:p1="clr-namespace:Bonsai.ML.LinearDynamicalSystems;assembly=Bonsai.ML.LinearDynamicalSystems"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p2="clr-namespace:Bonsai.ML.LinearDynamicalSystems.LinearRegression;assembly=Bonsai.ML.LinearDynamicalSystems"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -25,57 +26,32 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:WithLatestFrom" />
       </Expression>
-      <Expression xsi:type="rx:Sink">
-        <Name>Predict</Name>
-        <Workflow>
-          <Nodes>
-            <Expression xsi:type="WorkflowInput">
-              <Name>Source1</Name>
-            </Expression>
-            <Expression xsi:type="Format">
-              <Format>{0}.predict()</Format>
-              <Selector>it.Item2</Selector>
-            </Expression>
-            <Expression xsi:type="InputMapping">
-              <PropertyMappings>
-                <Property Name="Script" Selector="it" />
-              </PropertyMappings>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>LDSModule</Name>
-            </Expression>
-            <Expression xsi:type="PropertyMapping">
-              <PropertyMappings>
-                <Property Name="Module" />
-              </PropertyMappings>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="py:Exec">
-                <py:Script>model.predict()</py:Script>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="WorkflowOutput" />
-          </Nodes>
-          <Edges>
-            <Edge From="0" To="1" Label="Source1" />
-            <Edge From="1" To="2" Label="Source1" />
-            <Edge From="2" To="5" Label="Source1" />
-            <Edge From="3" To="4" Label="Source1" />
-            <Edge From="4" To="5" Label="Source2" />
-            <Edge From="5" To="6" Label="Source1" />
-          </Edges>
-        </Workflow>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Item2</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p2:GridParameters">
+          <p2:X0>-1</p2:X0>
+          <p2:X1>1</p2:X1>
+          <p2:Xsteps>100</p2:Xsteps>
+          <p2:Y0>-1</p2:Y0>
+          <p2:Y1>1</p2:Y1>
+          <p2:Ysteps>100</p2:Ysteps>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:WithLatestFrom" />
       </Expression>
       <Expression xsi:type="rx:Sink">
-        <Name>Update</Name>
+        <Name>PDF</Name>
         <Workflow>
           <Nodes>
             <Expression xsi:type="WorkflowInput">
               <Name>Source1</Name>
             </Expression>
             <Expression xsi:type="Format">
-              <Format>{0}.update({1})</Format>
-              <Selector>it.Item2, it.Item1</Selector>
+              <Format>{0}.pdf({1})</Format>
+              <Selector>it.Item1, it.Item2</Selector>
             </Expression>
             <Expression xsi:type="InputMapping">
               <PropertyMappings>
@@ -92,7 +68,7 @@
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="py:Exec">
-                <py:Script>model.update(x=0,y=0)</py:Script>
+                <py:Script>model.pdf(x0=-1,x1=1,xsteps=100,y0=-1,y1=1,ysteps=100)</py:Script>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
@@ -109,7 +85,7 @@
       </Expression>
       <Expression xsi:type="InputMapping">
         <PropertyMappings>
-          <Property Name="VariableName" Selector="it.Item2" />
+          <Property Name="VariableName" Selector="it.Item1" />
         </PropertyMappings>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
@@ -126,7 +102,7 @@
         </Combinator>
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="p1:State" />
+        <Combinator xsi:type="p2:MultivariatePDF" />
       </Expression>
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
@@ -137,13 +113,15 @@
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="4" To="5" Label="Source2" />
       <Edge From="5" To="6" Label="Source1" />
-      <Edge From="6" To="7" Label="Source1" />
-      <Edge From="7" To="8" Label="Source1" />
-      <Edge From="8" To="11" Label="Source1" />
+      <Edge From="6" To="8" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
       <Edge From="9" To="10" Label="Source1" />
-      <Edge From="10" To="11" Label="Source2" />
+      <Edge From="10" To="13" Label="Source1" />
       <Edge From="11" To="12" Label="Source1" />
-      <Edge From="12" To="13" Label="Source1" />
+      <Edge From="12" To="13" Label="Source2" />
+      <Edge From="13" To="14" Label="Source1" />
+      <Edge From="14" To="15" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateMultivariatePDF.bonsai
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/CreateMultivariatePDF.bonsai
@@ -32,19 +32,19 @@
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="X0" Category="GridParameters" />
         <Property Name="X1" Category="GridParameters" />
-        <Property Name="Xsteps" Category="GridParameters" />
+        <Property Name="XSteps" Category="GridParameters" />
         <Property Name="Y0" Category="GridParameters" />
         <Property Name="Y1" Category="GridParameters" />
-        <Property Name="Ysteps" Category="GridParameters" />
+        <Property Name="YSteps" Category="GridParameters" />
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="p2:GridParameters">
           <p2:X0>-1</p2:X0>
           <p2:X1>1</p2:X1>
-          <p2:Xsteps>100</p2:Xsteps>
+          <p2:XSteps>100</p2:XSteps>
           <p2:Y0>-1</p2:Y0>
           <p2:Y1>1</p2:Y1>
-          <p2:Ysteps>100</p2:Ysteps>
+          <p2:YSteps>100</p2:YSteps>
         </Combinator>
       </Expression>
       <Expression xsi:type="Combinator">
@@ -76,7 +76,7 @@
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="py:Exec">
-                <py:Script>model.pdf(x0=-1,x1=1,xsteps=100,y0=-1,y1=1,ysteps=100)</py:Script>
+                <py:Script>model.pdf(x0=-1, x1=1, xsteps=100, y0=-1, y1=1, ysteps=100)</py:Script>
               </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/GridParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/GridParameters.cs
@@ -1,0 +1,214 @@
+using System.ComponentModel;
+using System;
+using System.Reactive.Linq;
+using Newtonsoft.Json;
+using Python.Runtime;
+
+namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
+{
+
+    /// <summary>
+    /// 2D grid parameters used for calculating the PDF of a multivariate distribution
+    /// </summary>
+    [Description("2D grid parameters used for calculating the PDF of a multivariate distribution")]
+    [Combinator()]
+    [WorkflowElementCategory(ElementCategory.Source)]
+    public class GridParameters
+    {
+
+        private double _x0 = 0;
+        private double _x1 = 1;
+        private int _xsteps = 100;
+
+        private double _y0 = 0;
+        private double _y1 = 1;
+        private int _ysteps = 100;
+
+        private string _x0String;
+        private string _x1String;
+        private string _xstepsString;
+
+        private string _y0String;
+        private string _y1String;
+        private string _ystepsString;
+
+        /// <summary>
+        /// Lower bound of the x axis
+        /// </summary>
+        [JsonProperty("x0")]
+        [Description("Lower bound of the x axis")]
+        public double X0
+        {
+            get
+            {
+                return _x0;
+            }
+            set
+            {
+                _x0 = value;
+                _x0String = double.IsNaN(_x0) ? "None" : _x0.ToString();
+
+            }
+        }
+    
+        /// <summary>
+        /// Upper bound of the x axis
+        /// </summary>
+        [JsonProperty("x1")]
+        [Description("Upper bound of the x axis")]
+        public double X1
+        {
+            get
+            {
+                return _x1;
+            }
+            set
+            {
+                _x1 = value;
+                _x1String = double.IsNaN(_x1) ? "None" : _x1.ToString();
+            }
+        }
+        
+        /// <summary>
+        /// Number of steps along the x axis
+        /// </summary>
+        [JsonProperty("xsteps")]
+        [Description("Number of steps along the x axis")]
+        public int Xsteps
+        {
+            get
+            {
+                return _xsteps;
+            }
+            set
+            {
+                _xsteps = value >= 0 ? value : _xsteps;
+                _xstepsString = _xsteps.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Lower bound of the y axis
+        /// </summary>
+        [JsonProperty("y0")]
+        [Description("Lower bound of the y axis")]
+        public double Y0
+        {
+            get
+            {
+                return _y0;
+            }
+            set
+            {
+                _y0 = value;
+                _y0String = double.IsNaN(_y0) ? "None" : _y0.ToString();
+            }
+        }
+    
+        /// <summary>
+        /// Upper bound of the y axis
+        /// </summary>
+        [JsonProperty("y1")]
+        [Description("Upper bound of the y axis")]
+        public double Y1
+        {
+            get
+            {
+                return _y1;
+            }
+            set
+            {
+                _y1 = value;
+                _y1String = double.IsNaN(_y1) ? "None" : _y1.ToString();
+            }
+        }
+        
+        /// <summary>
+        /// Number of steps along the y axis
+        /// </summary>
+        [JsonProperty("ysteps")]
+        [Description("Number of steps along the y axis")]
+        public int Ysteps
+        {
+            get
+            {
+                return _ysteps;
+            }
+            set
+            {
+                _ysteps = value;
+                _ystepsString = _ysteps.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Generates grid parameters
+        /// </summary>    
+        public IObservable<GridParameters> Process()
+        {
+    		return Observable.Defer(() => Observable.Return(
+    			new GridParameters {
+    				X0 = _x0,
+                    X1 = _x1,
+                    Xsteps = _xsteps,
+    				Y0 = _y0,
+                    Y1 = _y1,
+                    Ysteps = _ysteps,
+    			}));
+        }
+
+        /// <summary>
+        /// Gets the grid parameters from a PyObject of a Kalman Filter Linear Regression Model
+        /// </summary>
+        public IObservable<GridParameters> Process(IObservable<PyObject> source)
+        {
+    		return Observable.Select(source, pyObject =>
+    		{
+                return ConvertPyObject(pyObject);
+            });
+        }
+
+        public static GridParameters ConvertPyObject(PyObject pyObject)
+        {
+            var x0PyObj = pyObject.GetAttr<double>("x0");
+            var x1PyObj = pyObject.GetAttr<double>("x1");
+            var xstepsPyObj = pyObject.GetAttr<int>("xsteps");
+
+            var y0PyObj = pyObject.GetAttr<double>("y0");
+            var y1PyObj = pyObject.GetAttr<double>("y1");
+            var ystepsPyObj = pyObject.GetAttr<int>("ysteps");
+
+            return new GridParameters {
+                X0 = x0PyObj,
+                X1 = x1PyObj,
+                Xsteps = xstepsPyObj,
+                Y0 = y0PyObj,
+                Y1 = y1PyObj,
+                Ysteps = ystepsPyObj,
+            };
+        }
+    
+        /// <summary>
+        /// Generates grid parameters on each input
+        /// </summary>
+        public IObservable<GridParameters> Process<TSource>(IObservable<TSource> source)
+        {
+            return Observable.Select(source, x =>
+                new GridParameters {
+    				X0 = _x0,
+                    X1 = _x1,
+                    Xsteps = _xsteps,
+    				Y0 = _y0,
+                    Y1 = _y1,
+                    Ysteps = _ysteps,
+                });
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+
+            return $"x0={_x0},x1={_x1},xsteps={_xsteps},y0={_y0},y1={_y1},ysteps={_ysteps}";
+        }
+    }
+}

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/GridParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/GridParameters.cs
@@ -8,10 +8,10 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
 {
 
     /// <summary>
-    /// 2D grid parameters used for calculating the PDF of a multivariate distribution
+    /// Represents an operator that creates the 2D grid parameters used for calculating the PDF of a multivariate distribution.
     /// </summary>
-    [Description("2D grid parameters used for calculating the PDF of a multivariate distribution")]
-    [Combinator()]
+    [Combinator]
+    [Description("Creates the 2D grid parameters used for calculating the PDF of a multivariate distribution.")]
     [WorkflowElementCategory(ElementCategory.Source)]
     public class GridParameters
     {
@@ -33,10 +33,10 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         private string _ystepsString;
 
         /// <summary>
-        /// Lower bound of the x axis
+        /// Gets or sets the lower bound of the X axis.
         /// </summary>
         [JsonProperty("x0")]
-        [Description("Lower bound of the x axis")]
+        [Description("The lower bound of the X axis")]
         public double X0
         {
             get
@@ -52,10 +52,10 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         }
     
         /// <summary>
-        /// Upper bound of the x axis
+        /// Gets or sets the upper bound of the X axis.
         /// </summary>
         [JsonProperty("x1")]
-        [Description("Upper bound of the x axis")]
+        [Description("The upper bound of the X axis")]
         public double X1
         {
             get
@@ -70,11 +70,11 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         }
         
         /// <summary>
-        /// Number of steps along the x axis
+        /// Gets or sets the number of steps along the X axis.
         /// </summary>
         [JsonProperty("xsteps")]
-        [Description("Number of steps along the x axis")]
-        public int Xsteps
+        [Description("The number of steps along the X axis")]
+        public int XSteps
         {
             get
             {
@@ -88,10 +88,10 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         }
 
         /// <summary>
-        /// Lower bound of the y axis
+        /// Gets or sets the lower bound of the Y axis.
         /// </summary>
         [JsonProperty("y0")]
-        [Description("Lower bound of the y axis")]
+        [Description("The lower bound of the Y axis")]
         public double Y0
         {
             get
@@ -106,10 +106,10 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         }
     
         /// <summary>
-        /// Upper bound of the y axis
+        /// Gets or sets the upper bound of the Y axis.
         /// </summary>
         [JsonProperty("y1")]
-        [Description("Upper bound of the y axis")]
+        [Description("The upper bound of the Y axis")]
         public double Y1
         {
             get
@@ -124,11 +124,11 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         }
         
         /// <summary>
-        /// Number of steps along the y axis
+        /// Gets or sets the number of steps along the Y axis.
         /// </summary>
         [JsonProperty("ysteps")]
-        [Description("Number of steps along the y axis")]
-        public int Ysteps
+        [Description("The number of steps along the Y axis")]
+        public int YSteps
         {
             get
             {
@@ -148,12 +148,12 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         {
     		return Observable.Defer(() => Observable.Return(
     			new GridParameters {
-    				X0 = _x0,
+                    X0 = _x0,
                     X1 = _x1,
-                    Xsteps = _xsteps,
-    				Y0 = _y0,
+                    XSteps = _xsteps,
+                    Y0 = _y0,
                     Y1 = _y1,
-                    Ysteps = _ysteps,
+                    YSteps = _ysteps,
     			}));
         }
 
@@ -168,23 +168,26 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
             });
         }
 
+        /// <summary>
+        /// Converts a PyObject, represeting a Kalman Filter Linear Regression Model, into a GridParameters object
+        /// </summary>
         public static GridParameters ConvertPyObject(PyObject pyObject)
         {
             var x0PyObj = pyObject.GetAttr<double>("x0");
             var x1PyObj = pyObject.GetAttr<double>("x1");
-            var xstepsPyObj = pyObject.GetAttr<int>("xsteps");
+            var xStepsPyObj = pyObject.GetAttr<int>("xsteps");
 
             var y0PyObj = pyObject.GetAttr<double>("y0");
             var y1PyObj = pyObject.GetAttr<double>("y1");
-            var ystepsPyObj = pyObject.GetAttr<int>("ysteps");
+            var yStepsPyObj = pyObject.GetAttr<int>("ysteps");
 
             return new GridParameters {
                 X0 = x0PyObj,
                 X1 = x1PyObj,
-                Xsteps = xstepsPyObj,
+                XSteps = xStepsPyObj,
                 Y0 = y0PyObj,
                 Y1 = y1PyObj,
-                Ysteps = ystepsPyObj,
+                YSteps = yStepsPyObj,
             };
         }
     
@@ -197,10 +200,10 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
                 new GridParameters {
     				X0 = _x0,
                     X1 = _x1,
-                    Xsteps = _xsteps,
+                    XSteps = _xsteps,
     				Y0 = _y0,
                     Y1 = _y1,
-                    Ysteps = _ysteps,
+                    YSteps = _ysteps,
                 });
         }
 
@@ -208,7 +211,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         public override string ToString()
         {
 
-            return $"x0={_x0},x1={_x1},xsteps={_xsteps},y0={_y0},y1={_y1},ysteps={_ysteps}";
+            return $"x0={_x0}, x1={_x1}, xsteps={_xsteps}, y0={_y0}, y1={_y1}, ysteps={_ysteps}";
         }
     }
 }

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/GridParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/GridParameters.cs
@@ -36,7 +36,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// Gets or sets the lower bound of the X axis.
         /// </summary>
         [JsonProperty("x0")]
-        [Description("The lower bound of the X axis")]
+        [Description("The lower bound of the X axis.")]
         public double X0
         {
             get
@@ -55,7 +55,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// Gets or sets the upper bound of the X axis.
         /// </summary>
         [JsonProperty("x1")]
-        [Description("The upper bound of the X axis")]
+        [Description("The upper bound of the X axis.")]
         public double X1
         {
             get
@@ -73,7 +73,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// Gets or sets the number of steps along the X axis.
         /// </summary>
         [JsonProperty("xsteps")]
-        [Description("The number of steps along the X axis")]
+        [Description("The number of steps along the X axis.")]
         public int XSteps
         {
             get
@@ -91,7 +91,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// Gets or sets the lower bound of the Y axis.
         /// </summary>
         [JsonProperty("y0")]
-        [Description("The lower bound of the Y axis")]
+        [Description("The lower bound of the Y axis.")]
         public double Y0
         {
             get
@@ -109,7 +109,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// Gets or sets the upper bound of the Y axis.
         /// </summary>
         [JsonProperty("y1")]
-        [Description("The upper bound of the Y axis")]
+        [Description("The upper bound of the Y axis.")]
         public double Y1
         {
             get
@@ -127,7 +127,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// Gets or sets the number of steps along the Y axis.
         /// </summary>
         [JsonProperty("ysteps")]
-        [Description("The number of steps along the Y axis")]
+        [Description("The number of steps along the Y axis.")]
         public int YSteps
         {
             get
@@ -146,15 +146,15 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// </summary>    
         public IObservable<GridParameters> Process()
         {
-    		return Observable.Defer(() => Observable.Return(
-    			new GridParameters {
+            return Observable.Defer(() => Observable.Return(
+                new GridParameters {
                     X0 = _x0,
                     X1 = _x1,
                     XSteps = _xsteps,
                     Y0 = _y0,
                     Y1 = _y1,
                     YSteps = _ysteps,
-    			}));
+                }));
         }
 
         /// <summary>
@@ -162,8 +162,8 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// </summary>
         public IObservable<GridParameters> Process(IObservable<PyObject> source)
         {
-    		return Observable.Select(source, pyObject =>
-    		{
+            return Observable.Select(source, pyObject =>
+            {
                 return ConvertPyObject(pyObject);
             });
         }
@@ -198,10 +198,10 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         {
             return Observable.Select(source, x =>
                 new GridParameters {
-    				X0 = _x0,
+                    X0 = _x0,
                     X1 = _x1,
                     XSteps = _xsteps,
-    				Y0 = _y0,
+                    Y0 = _y0,
                     Y1 = _y1,
                     YSteps = _ysteps,
                 });

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/KFModelParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/KFModelParameters.cs
@@ -1,0 +1,150 @@
+using System.ComponentModel;
+using Newtonsoft.Json;
+using System;
+using System.Reactive.Linq;
+using Python.Runtime;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
+{
+
+    /// <summary>
+    /// Model parameters for a Kalman Filter Kinematics python class
+    /// </summary>
+    [Description("Model parameters for a Kalman Filter Linear Regression (KFLR) model")]
+    [Combinator()]
+    [WorkflowElementCategory(ElementCategory.Source)]
+    public class KFModelParameters
+    {
+
+        private double _likelihood_precision_coef;
+
+        private double _prior_precision_coef;
+    
+        private double[,] _mn = null;
+    
+        private string _likelihood_precision_coefString;
+        private string _prior_precision_coefString;
+        private string _mnString;
+
+        /// <summary>
+        /// likelihood precision coefficient
+        /// </summary>
+        [JsonProperty("likelihood_precision_coef")]
+        [Description("likelihood precision coefficient")]
+        public double LikelihoodPrecisionCoef
+        {
+            get
+            {
+                return _likelihood_precision_coef;
+            }
+            set
+            {
+                _likelihood_precision_coef = value;
+                _likelihood_precision_coefString = double.IsNaN(_likelihood_precision_coef) ? "None" : _likelihood_precision_coef.ToString();
+            }
+        }
+    
+        /// <summary>
+        /// prior precision coefficient
+        /// </summary>
+        [JsonProperty("prior_precision_coef")]
+        [Description("prior precision coefficient")]
+        public double PriorPrecisionCoef
+        {
+            get
+            {
+                return _prior_precision_coef;
+            }
+            set
+            {
+                _prior_precision_coef = value;
+                _prior_precision_coefString = double.IsNaN(_prior_precision_coef) ? "None" : _prior_precision_coef.ToString();
+            }
+        }
+    
+        /// <summary>
+        /// mean of the prior
+        /// </summary>
+        [JsonProperty("mn")]
+        [Description("mean of the prior")]
+        public double[,] Mn
+        {
+            get
+            {
+                return _mn;
+            }
+            set
+            {
+                _mn = value;
+                if (_mn == null || _mn.Length == 0) _mnString = "None";
+                else
+                {
+                    _mnString = NumpyHelper.NumpyParser.ParseArray(_mn);
+                }
+            }
+        }
+    
+        public KFModelParameters ()
+        {
+            LikelihoodPrecisionCoef = 25;
+            PriorPrecisionCoef = 2;
+        }
+
+        /// <summary>
+        /// Generates parameters for a Kalman Filter Linear Regression Model
+        /// </summary>
+        public IObservable<KFModelParameters> Process()
+        {
+    		return Observable.Defer(() => Observable.Return(
+    			new KFModelParameters {
+    				LikelihoodPrecisionCoef = _likelihood_precision_coef,
+                    PriorPrecisionCoef = _prior_precision_coef,
+                    Mn = _mn
+    			}));
+        }
+
+        /// <summary>
+        /// Gets the model parameters from a PyObject of a Kalman Filter Linear Regression Model
+        /// </summary>
+        public IObservable<KFModelParameters> Process(IObservable<PyObject> source)
+        {
+    		return Observable.Select(source, pyObject =>
+    		{
+                // var likelihood_precision_coefPyObj = GetPythonAttribute<double>(pyObject, "likelihood_precision_coef");
+                var likelihood_precision_coefPyObj = pyObject.GetAttr<double>("likelihood_precision_coef");
+                // var prior_precision_coefPyObj = GetPythonAttribute<double>(pyObject, "prior_precision_coef");
+                var prior_precision_coefPyObj = pyObject.GetAttr<double>("prior_precision_coef");
+                // var mnPyObj = (double[])GetPythonAttribute(pyObject, "mn");
+                var mnPyObj = (double[,])pyObject.GetArrayAttribute("mn");
+
+                return new KFModelParameters {
+                    LikelihoodPrecisionCoef = likelihood_precision_coefPyObj,
+                    PriorPrecisionCoef = _prior_precision_coef,
+                    Mn = mnPyObj
+                };
+            });
+        }
+    
+        /// <summary>
+        /// Generates parameters for a Kalman Filter Linear Regression Model on each input
+        /// </summary>
+        public IObservable<KFModelParameters> Process<TSource>(IObservable<TSource> source)
+        {
+            return Observable.Select(source, x =>
+                new KFModelParameters {
+    				LikelihoodPrecisionCoef = _likelihood_precision_coef,
+                    PriorPrecisionCoef = _prior_precision_coef,
+                    Mn = _mn
+                });
+        }
+    
+        public override string ToString()
+        {
+
+            return $"likelihood_precision_coef={_likelihood_precision_coefString},prior_precision_coef={_prior_precision_coefString},mn={_mnString}";
+        }
+    }
+
+}

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/KFModelParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/KFModelParameters.cs
@@ -21,17 +21,23 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
 
         private double _prior_precision_coef;
     
-        private double[,] _mn = null;
+        private int _n_features;
+
+        private double[,] _x = null;
+        private double[,] _p = null;
     
         private string _likelihood_precision_coefString;
         private string _prior_precision_coefString;
-        private string _mnString;
+        private string _n_featuresString;
+        private string _xString;
+        private string _pString;
 
         /// <summary>
         /// likelihood precision coefficient
         /// </summary>
         [JsonProperty("likelihood_precision_coef")]
         [Description("likelihood precision coefficient")]
+        [Category("Parameters")]
         public double LikelihoodPrecisionCoef
         {
             get
@@ -50,6 +56,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// </summary>
         [JsonProperty("prior_precision_coef")]
         [Description("prior precision coefficient")]
+        [Category("Parameters")]
         public double PriorPrecisionCoef
         {
             get
@@ -64,25 +71,61 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         }
     
         /// <summary>
-        /// mean of the prior
+        /// number of features
         /// </summary>
-        [XmlIgnore]
-        [JsonProperty("mn")]
-        [Description("mean of the prior")]
-        public double[,] Mn
+        [JsonProperty("n_features")]
+        [Description("number of features")]
+        [Category("Parameters")]
+        public int NumFeatures
         {
             get
             {
-                return _mn;
+                return _n_features;
             }
             set
             {
-                _mn = value;
-                if (_mn == null || _mn.Length == 0) _mnString = "None";
-                else
-                {
-                    _mnString = NumpyHelper.NumpyParser.ParseArray(_mn);
-                }
+                _n_features = value;
+                _n_featuresString = _n_features.ToString();
+            }
+        }
+
+        /// <summary>
+        /// matrix representing the mean of the state
+        /// </summary>
+        [XmlIgnore]
+        [JsonProperty("x")]
+        [Description("matrix representing the mean of the state")]
+        [Category("ModelState")]
+        public double[,] X
+        {
+            get
+            {
+                return _x;
+            }
+            set
+            {
+                _x = value;
+                _xString = _x == null ? "None" : NumpyHelper.NumpyParser.ParseArray(_x);
+            }
+        }
+
+        /// <summary>
+        /// matrix representing the covariance of the state
+        /// </summary>
+        [XmlIgnore]
+        [JsonProperty("P")]
+        [Description("matrix representing the covariance of the state")]
+        [Category("ModelState")]
+        public double[,] P
+        {
+            get
+            {
+                return _p;
+            }
+            set
+            {
+                _p = value;
+                _pString = _p == null ? "None" : NumpyHelper.NumpyParser.ParseArray(_p);
             }
         }
     
@@ -101,7 +144,9 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
     			new KFModelParameters {
     				LikelihoodPrecisionCoef = _likelihood_precision_coef,
                     PriorPrecisionCoef = _prior_precision_coef,
-                    Mn = _mn
+                    NumFeatures = _n_features,
+                    X = _x,
+                    P = _p
     			}));
         }
 
@@ -114,12 +159,14 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
     		{
                 var likelihood_precision_coefPyObj = pyObject.GetAttr<double>("likelihood_precision_coef");
                 var prior_precision_coefPyObj = pyObject.GetAttr<double>("prior_precision_coef");
-                var mnPyObj = (double[,])pyObject.GetArrayAttribute("mn");
+                var n_featuresPyObj = pyObject.GetAttr<int>("n_features");
 
                 return new KFModelParameters {
                     LikelihoodPrecisionCoef = likelihood_precision_coefPyObj,
                     PriorPrecisionCoef = _prior_precision_coef,
-                    Mn = mnPyObj
+                    NumFeatures = n_featuresPyObj,
+                    X = _x,
+                    P = _p
                 };
             });
         }
@@ -133,14 +180,16 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
                 new KFModelParameters {
     				LikelihoodPrecisionCoef = _likelihood_precision_coef,
                     PriorPrecisionCoef = _prior_precision_coef,
-                    Mn = _mn
+                    NumFeatures = _n_features,
+                    X = _x,
+                    P = _p
                 });
         }
     
         public override string ToString()
         {
 
-            return $"likelihood_precision_coef={_likelihood_precision_coefString},prior_precision_coef={_prior_precision_coefString},mn={_mnString}";
+            return $"likelihood_precision_coef={_likelihood_precision_coefString},prior_precision_coef={_prior_precision_coefString},n_features={_n_featuresString},x={_xString},P={_pString}";
         }
     }
 

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/KFModelParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/KFModelParameters.cs
@@ -3,8 +3,7 @@ using Newtonsoft.Json;
 using System;
 using System.Reactive.Linq;
 using Python.Runtime;
-using System.Collections.Generic;
-using System.Linq;
+using System.Xml.Serialization;
 
 namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
 {
@@ -67,6 +66,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// <summary>
         /// mean of the prior
         /// </summary>
+        [XmlIgnore]
         [JsonProperty("mn")]
         [Description("mean of the prior")]
         public double[,] Mn
@@ -112,11 +112,8 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         {
     		return Observable.Select(source, pyObject =>
     		{
-                // var likelihood_precision_coefPyObj = GetPythonAttribute<double>(pyObject, "likelihood_precision_coef");
                 var likelihood_precision_coefPyObj = pyObject.GetAttr<double>("likelihood_precision_coef");
-                // var prior_precision_coefPyObj = GetPythonAttribute<double>(pyObject, "prior_precision_coef");
                 var prior_precision_coefPyObj = pyObject.GetAttr<double>("prior_precision_coef");
-                // var mnPyObj = (double[])GetPythonAttribute(pyObject, "mn");
                 var mnPyObj = (double[,])pyObject.GetArrayAttribute("mn");
 
                 return new KFModelParameters {

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/KFModelParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/KFModelParameters.cs
@@ -36,7 +36,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// Gets or sets the likelihood precision coefficient.
         /// </summary>
         [JsonProperty("likelihood_precision_coef")]
-        [Description("The likelihood precision coefficient")]
+        [Description("The likelihood precision coefficient.")]
         [Category("Parameters")]
         public double LikelihoodPrecisionCoefficient
         {
@@ -55,7 +55,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// Gets or sets the prior precision coefficient.
         /// </summary>
         [JsonProperty("prior_precision_coef")]
-        [Description("The prior precision coefficient")]
+        [Description("The prior precision coefficient.")]
         [Category("Parameters")]
         public double PriorPrecisionCoefficient
         {
@@ -74,7 +74,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// Gets or sets the number of features present in the model.
         /// </summary>
         [JsonProperty("n_features")]
-        [Description("The number of features")]
+        [Description("The number of features.")]
         [Category("Parameters")]
         public int NumFeatures
         {
@@ -94,7 +94,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// </summary>
         [XmlIgnore]
         [JsonProperty("x")]
-        [Description("The matrix representing the mean of the state")]
+        [Description("The matrix representing the mean of the state.")]
         [Category("ModelState")]
         public double[,] X
         {
@@ -143,14 +143,14 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// </summary>
         public IObservable<KFModelParameters> Process()
         {
-    		return Observable.Defer(() => Observable.Return(
-    			new KFModelParameters {
-    				LikelihoodPrecisionCoefficient = _likelihood_precision_coef,
+            return Observable.Defer(() => Observable.Return(
+                new KFModelParameters {
+                    LikelihoodPrecisionCoefficient = _likelihood_precision_coef,
                     PriorPrecisionCoefficient = _prior_precision_coef,
                     NumFeatures = _n_features,
                     X = _x,
                     P = _p
-    			}));
+                }));
         }
 
         /// <summary>
@@ -158,8 +158,8 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         /// </summary>
         public IObservable<KFModelParameters> Process(IObservable<PyObject> source)
         {
-    		return Observable.Select(source, pyObject =>
-    		{
+            return Observable.Select(source, pyObject =>
+            {
                 var likelihood_precision_coefPyObj = pyObject.GetAttr<double>("likelihood_precision_coef");
                 var prior_precision_coefPyObj = pyObject.GetAttr<double>("prior_precision_coef");
                 var n_featuresPyObj = pyObject.GetAttr<int>("n_features");
@@ -181,7 +181,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         {
             return Observable.Select(source, x =>
                 new KFModelParameters {
-    				LikelihoodPrecisionCoefficient = _likelihood_precision_coef,
+                    LikelihoodPrecisionCoefficient = _likelihood_precision_coef,
                     PriorPrecisionCoefficient = _prior_precision_coef,
                     NumFeatures = _n_features,
                     X = _x,

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/KFModelParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/KFModelParameters.cs
@@ -9,10 +9,10 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
 {
 
     /// <summary>
-    /// Model parameters for a Kalman Filter Kinematics python class
+    /// Represents an operator that creates the model parameters for a Kalman Filter Linear Regression python class
     /// </summary>
-    [Description("Model parameters for a Kalman Filter Linear Regression (KFLR) model")]
-    [Combinator()]
+    [Combinator]
+    [Description("Creates the model parameters used for initializing a Kalman Filter Linear Regression (KFLR) python class")]
     [WorkflowElementCategory(ElementCategory.Source)]
     public class KFModelParameters
     {
@@ -33,12 +33,12 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         private string _pString;
 
         /// <summary>
-        /// likelihood precision coefficient
+        /// Gets or sets the likelihood precision coefficient.
         /// </summary>
         [JsonProperty("likelihood_precision_coef")]
-        [Description("likelihood precision coefficient")]
+        [Description("The likelihood precision coefficient")]
         [Category("Parameters")]
-        public double LikelihoodPrecisionCoef
+        public double LikelihoodPrecisionCoefficient
         {
             get
             {
@@ -52,12 +52,12 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         }
     
         /// <summary>
-        /// prior precision coefficient
+        /// Gets or sets the prior precision coefficient.
         /// </summary>
         [JsonProperty("prior_precision_coef")]
-        [Description("prior precision coefficient")]
+        [Description("The prior precision coefficient")]
         [Category("Parameters")]
-        public double PriorPrecisionCoef
+        public double PriorPrecisionCoefficient
         {
             get
             {
@@ -71,10 +71,10 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         }
     
         /// <summary>
-        /// number of features
+        /// Gets or sets the number of features present in the model.
         /// </summary>
         [JsonProperty("n_features")]
-        [Description("number of features")]
+        [Description("The number of features")]
         [Category("Parameters")]
         public int NumFeatures
         {
@@ -90,11 +90,11 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         }
 
         /// <summary>
-        /// matrix representing the mean of the state
+        /// Gets or sets the matrix representing the mean of the state.
         /// </summary>
         [XmlIgnore]
         [JsonProperty("x")]
-        [Description("matrix representing the mean of the state")]
+        [Description("The matrix representing the mean of the state")]
         [Category("ModelState")]
         public double[,] X
         {
@@ -110,11 +110,11 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         }
 
         /// <summary>
-        /// matrix representing the covariance of the state
+        /// Gets or sets the matrix representing the covariance between state components.
         /// </summary>
         [XmlIgnore]
         [JsonProperty("P")]
-        [Description("matrix representing the covariance of the state")]
+        [Description("The matrix representing the covariance between state components.")]
         [Category("ModelState")]
         public double[,] P
         {
@@ -128,11 +128,14 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
                 _pString = _p == null ? "None" : NumpyHelper.NumpyParser.ParseArray(_p);
             }
         }
-    
+
+        /// <summary>
+        /// Constructs a KF Model Parameters class.
+        /// </summary>
         public KFModelParameters ()
         {
-            LikelihoodPrecisionCoef = 25;
-            PriorPrecisionCoef = 2;
+            LikelihoodPrecisionCoefficient = 25;
+            PriorPrecisionCoefficient = 2;
         }
 
         /// <summary>
@@ -142,8 +145,8 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         {
     		return Observable.Defer(() => Observable.Return(
     			new KFModelParameters {
-    				LikelihoodPrecisionCoef = _likelihood_precision_coef,
-                    PriorPrecisionCoef = _prior_precision_coef,
+    				LikelihoodPrecisionCoefficient = _likelihood_precision_coef,
+                    PriorPrecisionCoefficient = _prior_precision_coef,
                     NumFeatures = _n_features,
                     X = _x,
                     P = _p
@@ -162,8 +165,8 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
                 var n_featuresPyObj = pyObject.GetAttr<int>("n_features");
 
                 return new KFModelParameters {
-                    LikelihoodPrecisionCoef = likelihood_precision_coefPyObj,
-                    PriorPrecisionCoef = _prior_precision_coef,
+                    LikelihoodPrecisionCoefficient = likelihood_precision_coefPyObj,
+                    PriorPrecisionCoefficient = _prior_precision_coef,
                     NumFeatures = n_featuresPyObj,
                     X = _x,
                     P = _p
@@ -178,8 +181,8 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         {
             return Observable.Select(source, x =>
                 new KFModelParameters {
-    				LikelihoodPrecisionCoef = _likelihood_precision_coef,
-                    PriorPrecisionCoef = _prior_precision_coef,
+    				LikelihoodPrecisionCoefficient = _likelihood_precision_coef,
+                    PriorPrecisionCoefficient = _prior_precision_coef,
                     NumFeatures = _n_features,
                     X = _x,
                     P = _p
@@ -189,7 +192,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
         public override string ToString()
         {
 
-            return $"likelihood_precision_coef={_likelihood_precision_coefString},prior_precision_coef={_prior_precision_coefString},n_features={_n_featuresString},x={_xString},P={_pString}";
+            return $"likelihood_precision_coef={_likelihood_precision_coefString}, prior_precision_coef={_prior_precision_coefString}, n_features={_n_featuresString}, x={_xString}, P={_pString}";
         }
     }
 

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/MultivariatePDF.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/MultivariatePDF.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using System;
+using System.Reactive.Linq;
+using Python.Runtime;
+using System.Xml.Serialization;
+
+namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
+{
+    /// <summary>
+    /// A class that converts a python object, representing a multivariate PDF, into a multidimensional array
+    /// /// </summary>
+    [Description("A multivariate PDF")]
+    [Combinator()]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class MultivariatePDF
+    {
+
+        [XmlIgnore]
+        public GridParameters GridParameters;
+
+        [XmlIgnore]
+        public double[,] Values;
+
+        /// <summary>
+        /// Converts a python object, representing a multivariate PDF, into a multidimensional array
+        /// </summary>
+        public IObservable<MultivariatePDF> Process(IObservable<PyObject> source)
+        {
+            return Observable.Select(source, pyObject =>
+            {
+                var gridParameters = GridParameters.ConvertPyObject(pyObject);
+                var values = (double[,])pyObject.GetArrayAttribute("pdf_values");
+                return new MultivariatePDF {
+                    GridParameters = gridParameters,
+                    Values = values
+                };
+            });
+        }
+    }
+}

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/MultivariatePDF.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/MultivariatePDF.cs
@@ -7,22 +7,28 @@ using System.Xml.Serialization;
 namespace Bonsai.ML.LinearDynamicalSystems.LinearRegression
 {
     /// <summary>
-    /// A class that converts a python object, representing a multivariate PDF, into a multidimensional array
-    /// /// </summary>
-    [Description("A multivariate PDF")]
-    [Combinator()]
+    /// Represents an operator that converts a python object, representing a multivariate PDF, into a multivariate PDF class.
+    /// </summary>
+    [Combinator]
+    [Description("Converts a python object, representing a multivariate PDF, into a multivariate PDF.")]
     [WorkflowElementCategory(ElementCategory.Transform)]
     public class MultivariatePDF
     {
 
+        /// <summary>
+        /// Gets or sets the grid parameters used for generating the multivariate PDF.
+        /// </summary>
         [XmlIgnore]
         public GridParameters GridParameters;
 
+        /// <summary>
+        /// Gets or sets the probability density value at each 2D position of the grid.
+        /// </summary>
         [XmlIgnore]
         public double[,] Values;
 
         /// <summary>
-        /// Converts a python object, representing a multivariate PDF, into a multidimensional array
+        /// Converts a PyObject into a multivariate PDF.
         /// </summary>
         public IObservable<MultivariatePDF> Process(IObservable<PyObject> source)
         {

--- a/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/PerformInference.bonsai
+++ b/src/Bonsai.ML.LinearDynamicalSystems/LinearRegression/PerformInference.bonsai
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
+                 xmlns:p1="clr-namespace:Bonsai.ML.LinearDynamicalSystems;assembly=Bonsai.ML.LinearDynamicalSystems"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:ObserveOnGIL" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="ModelName" Category="Reference" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateModelNameReference">
+          <p1:Name>model</p1:Name>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:WithLatestFrom" />
+      </Expression>
+      <Expression xsi:type="rx:Sink">
+        <Name>Predict</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="Format">
+              <Format>{0}.predict()</Format>
+              <Selector>it.Item2</Selector>
+            </Expression>
+            <Expression xsi:type="InputMapping">
+              <PropertyMappings>
+                <Property Name="Script" Selector="it" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>LDSModule</Name>
+            </Expression>
+            <Expression xsi:type="PropertyMapping">
+              <PropertyMappings>
+                <Property Name="Module" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="py:Exec">
+                <py:Script>model.predict()</py:Script>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="5" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="4" To="5" Label="Source2" />
+            <Edge From="5" To="6" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="rx:Sink">
+        <Name>Update</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="Format">
+              <Format>{0}.update({1})</Format>
+              <Selector>it.Item2, it.Item1</Selector>
+            </Expression>
+            <Expression xsi:type="InputMapping">
+              <PropertyMappings>
+                <Property Name="Script" Selector="it" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>LDSModule</Name>
+            </Expression>
+            <Expression xsi:type="PropertyMapping">
+              <PropertyMappings>
+                <Property Name="Module" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="py:Exec">
+                <py:Script>model.update(x=0,y=0)</py:Script>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="5" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="4" To="5" Label="Source2" />
+            <Edge From="5" To="6" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="InputMapping">
+        <PropertyMappings>
+          <Property Name="VariableName" Selector="it.Item2" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>LDSModule</Name>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="Module" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:Get">
+          <py:VariableName>model</py:VariableName>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:State" />
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="4" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="4" Label="Source2" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="10" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source2" />
+      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="11" To="12" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/Bonsai.ML.LinearDynamicalSystems/Reshape.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Reshape.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Reactive.Linq;
+
+namespace Bonsai.ML.LinearDynamicalSystems
+{
+    /// <summary>
+    /// A class that converts a python object, representing a multivariate PDF, into a multidimensional array
+    /// /// </summary>
+    [Combinator()]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class Reshape
+    {
+        public int Rows {get;set;}
+        public int Cols {get;set;}
+
+        public IObservable<double[,]> Process(IObservable<double[,]> source)
+        {
+
+            var rows = Rows;
+            var cols = Cols;
+
+            return Observable.Select(source, value =>
+            {
+                var inputRows = value.GetLength(0);
+                var inputCols = value.GetLength(1);
+                int totalElements = inputRows * inputCols;
+
+                if (totalElements != rows * cols)
+                {
+                    throw new InvalidOperationException($"Multidimensional array of shape {rows}x{cols} cannot be made from input array with a total of {totalElements} elements.");
+                }
+
+                double[,] reshapedArray = new double[rows, cols];
+
+                for (int i = 0; i < totalElements; i++)
+                {
+                    int originalRow = i / inputCols;
+                    int originalCol = i % inputCols;
+
+                    int newRow = i / cols;
+                    int newCol = i % cols;
+
+                    reshapedArray[newRow, newCol] = value[originalRow, originalCol];
+                }
+
+                return reshapedArray;
+            });    
+        }
+    }
+}

--- a/src/Bonsai.ML.LinearDynamicalSystems/Reshape.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Reshape.cs
@@ -1,18 +1,32 @@
 using System;
 using System.Reactive.Linq;
+using System.ComponentModel;
 
 namespace Bonsai.ML.LinearDynamicalSystems
 {
     /// <summary>
-    /// A class that converts a python object, representing a multivariate PDF, into a multidimensional array
-    /// /// </summary>
-    [Combinator()]
+    /// Represents an operator that reshapes the dimensions of a 2D multi-dimensional array.
+    /// </summary>
+    [Combinator]
+    [Description("Reshapes the dimensions of a 2D multi-dimensional array.")]
     [WorkflowElementCategory(ElementCategory.Transform)]
     public class Reshape
     {
-        public int Rows {get;set;}
-        public int Cols {get;set;}
+        /// <summary>
+        /// Gets or sets the number of rows in the reshaped array.
+        /// </summary>
+        [Description("The number of rows in the reshaped array.")]
+        public int Rows { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of columns in the reshaped array.
+        /// </summary>
+        [Description("The number of columns in the reshaped array.")]
+        public int Cols { get; set; }
+
+        /// <summary>
+        /// Reshapes a 2D multi-dimensional array into a new multi-dimensional array with the provided number of rows and columns.
+        /// </summary>
         public IObservable<double[,]> Process(IObservable<double[,]> source)
         {
 
@@ -27,7 +41,7 @@ namespace Bonsai.ML.LinearDynamicalSystems
 
                 if (totalElements != rows * cols)
                 {
-                    throw new InvalidOperationException($"Multidimensional array of shape {rows}x{cols} cannot be made from input array with a total of {totalElements} elements.");
+                    throw new InvalidOperationException($"Multi-dimensional array of shape {rows}x{cols} cannot be made from the input array with a total of {totalElements} elements.");
                 }
 
                 double[,] reshapedArray = new double[rows, cols];

--- a/src/Bonsai.ML.LinearDynamicalSystems/SerializeToJson.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/SerializeToJson.cs
@@ -47,5 +47,10 @@ namespace Bonsai.ML.LinearDynamicalSystems
         {
             return Process<Kinematics.KinematicComponent>(source);
         }
+
+        public IObservable<string> Process(IObservable<LinearRegression.KFModelParameters> source)
+        {
+            return Process<LinearRegression.KFModelParameters>(source);
+        }
     }
 }

--- a/src/Bonsai.ML.LinearDynamicalSystems/Slice.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Slice.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Reactive.Linq;
+
+namespace Bonsai.ML.LinearDynamicalSystems
+{
+    /// <summary>
+    /// A class that converts a python object, representing a multivariate PDF, into a multidimensional array
+    /// /// </summary>
+    [Combinator()]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class Slice
+    {
+        public int? RowStart {get;set;} = null;
+        public int? RowEnd {get;set;} = null;
+        public int? ColStart {get;set;} = null;
+        public int? ColEnd {get;set;} = null;
+
+        public IObservable<double[,]> Process(IObservable<double[,]> source)
+        {
+
+            int rowStart = RowStart.HasValue ? RowStart.Value : 0;
+            int rowEnd = RowEnd.HasValue ? RowEnd.Value : int.MaxValue;
+
+            int colStart = ColStart.HasValue ? ColStart.Value : 0;
+            int colEnd = ColEnd.HasValue ? ColEnd.Value : int.MaxValue;
+
+            if (rowEnd < rowStart)
+            {
+                throw new InvalidOperationException("Starting row must be less than or equal to ending row.");
+            }
+
+            if (colEnd < colStart)
+            {
+                throw new InvalidOperationException("Starting column must be less than or equal to ending column.");
+            }
+
+            return Observable.Select(source, value =>
+            {
+                var inputRows = value.GetLength(0);
+                var inputCols = value.GetLength(1);
+
+                if (rowEnd == int.MaxValue)
+                {
+                    rowEnd = inputRows;
+                }
+
+                if (colEnd == int.MaxValue)
+                {
+                    colEnd = inputCols;
+                }
+
+                // Calculate the size of the new sliced array
+                int rowCount = rowEnd - rowStart;
+                int colCount = colEnd - colStart;
+
+                // Initialize the new array with the calculated size
+                double[,] slicedArray = new double[rowCount, colCount];
+
+                // Copy the data from the original array to the new array
+                for (int i = 0; i < rowCount; i++)
+                {
+                    for (int j = 0; j < colCount; j++)
+                    {
+                        slicedArray[i, j] = value[rowStart + i, colStart + j];
+                    }
+                }
+
+                return slicedArray;
+            });    
+        }
+    }
+}

--- a/src/Bonsai.ML.LinearDynamicalSystems/Slice.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Slice.cs
@@ -1,20 +1,45 @@
 using System;
 using System.Reactive.Linq;
+using System.ComponentModel;
 
 namespace Bonsai.ML.LinearDynamicalSystems
 {
     /// <summary>
-    /// A class that converts a python object, representing a multivariate PDF, into a multidimensional array
-    /// /// </summary>
-    [Combinator()]
+    /// Represents an operator that slices a 2D multi-dimensional array.
+    /// </summary>
+    [Combinator]
+    [Description("Slices a 2D multi-dimensional array.")]
     [WorkflowElementCategory(ElementCategory.Transform)]
     public class Slice
     {
-        public int? RowStart {get;set;} = null;
-        public int? RowEnd {get;set;} = null;
-        public int? ColStart {get;set;} = null;
-        public int? ColEnd {get;set;} = null;
 
+        /// <summary>
+        /// Gets or sets the index to begin slicing the rows of the array. A value of null indicates the first row of the array.
+        /// </summary>
+        [Description("The index to begin slicing the rows of the array. A value of null indicates the first row of the array.")]
+        public int? RowStart { get; set; }
+
+        /// <summary>
+        /// Gets or sets the index to stop slicing the rows of the array. A value of null indicates the last row of the array.
+        /// </summary>
+        [Description("The index to stop slicing the rows of the array. A value of null indicates the last row of the array.")]
+        public int? RowEnd { get; set; }
+
+        /// <summary>
+        /// Gets or sets the index to begin slicing the columns of the array. A value of null indicates the first column of the array.
+        /// </summary>
+        [Description("The index to begin slicing the columns of the array. A value of null indicates the first column of the array.")]
+        public int? ColStart { get; set; }
+
+        /// <summary>
+        /// Gets or sets the index to stop slicing the columns of the array. A value of null indicates the last column of the array.
+        /// </summary>
+        [Description("The index to stop slicing the columns of the array. A value of null indicates the last column of the array.")]
+        public int? ColEnd { get; set; }
+
+        /// <summary>
+        /// Slices a 2D multi-dimensional array into a new multi-dimensional array by extracting elements between the provided start and end indices of the rows and columns.
+        /// </summary>
         public IObservable<double[,]> Process(IObservable<double[,]> source)
         {
 
@@ -49,14 +74,11 @@ namespace Bonsai.ML.LinearDynamicalSystems
                     colEnd = inputCols;
                 }
 
-                // Calculate the size of the new sliced array
                 int rowCount = rowEnd - rowStart;
                 int colCount = colEnd - colStart;
 
-                // Initialize the new array with the calculated size
                 double[,] slicedArray = new double[rowCount, colCount];
 
-                // Copy the data from the original array to the new array
                 for (int i = 0; i < rowCount; i++)
                 {
                     for (int j = 0; j < colCount; j++)

--- a/src/Bonsai.ML.LinearDynamicalSystems/StateComponent.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/StateComponent.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System;
 using System.Xml.Serialization;
+using System.Reactive.Linq;
 using Newtonsoft.Json;
 
 namespace Bonsai.ML.LinearDynamicalSystems
@@ -53,7 +54,14 @@ namespace Bonsai.ML.LinearDynamicalSystems
         }
 
         /// <summary>
-        /// Extracts a single state compenent from the full state
+        /// Base constructor of a state component
+        /// </summary>
+        public StateComponent() 
+        {
+        }
+
+        /// <summary>
+        /// Constructs a state compenent from the full state and covariance matrices given an index
         /// </summary>
         public StateComponent(double[,] X, double[,] P, int i) 
         {
@@ -64,6 +72,32 @@ namespace Bonsai.ML.LinearDynamicalSystems
         private double Sigma(double variance)
         {
             return 2 * Math.Sqrt(variance);
+        }
+
+        /// <summary>
+        /// Generates a state component
+        /// </summary>
+        public IObservable<StateComponent> Process()
+        {
+    		return Observable.Defer(() => Observable.Return(
+    			new StateComponent {
+                    Mean = _mean,
+                    Variance = _variance
+    			}));
+        }
+
+        /// <summary>
+        /// Generates a state component
+        /// </summary>
+        public IObservable<StateComponent> Process<TSource>(IObservable<TSource> source)
+        {
+            return Observable.Select(source, pyObject =>
+            {
+                return new StateComponent {
+                    Mean = _mean,
+                    Variance = _variance
+                };
+            });
         }
     }
 }

--- a/src/Bonsai.ML.LinearDynamicalSystems/StateComponent.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/StateComponent.cs
@@ -54,14 +54,15 @@ namespace Bonsai.ML.LinearDynamicalSystems
         }
 
         /// <summary>
-        /// Base constructor of a state component
+        /// Initializes a new instance of the <see cref="Bonsai.ML.LinearDynamicalSystems.StateComponent"/> class.
         /// </summary>
         public StateComponent() 
         {
         }
 
         /// <summary>
-        /// Constructs a state compenent from the full state and covariance matrices given an index
+        /// Initializes a new instance of the <see cref="Bonsai.ML.LinearDynamicalSystems.StateComponent"/> class from 
+        /// the full state and covariance matrices given an index
         /// </summary>
         public StateComponent(double[,] X, double[,] P, int i) 
         {

--- a/src/Bonsai.ML.LinearDynamicalSystems/StateComponent.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/StateComponent.cs
@@ -80,11 +80,11 @@ namespace Bonsai.ML.LinearDynamicalSystems
         /// </summary>
         public IObservable<StateComponent> Process()
         {
-    		return Observable.Defer(() => Observable.Return(
-    			new StateComponent {
+            return Observable.Defer(() => Observable.Return(
+                new StateComponent {
                     Mean = _mean,
                     Variance = _variance
-    			}));
+                }));
         }
 
         /// <summary>

--- a/src/Bonsai.ML.LinearDynamicalSystems/main.py
+++ b/src/Bonsai.ML.LinearDynamicalSystems/main.py
@@ -83,7 +83,7 @@ class KalmanFilterLinearRegression(TimeVaryingOnlineKalmanFilter):
                     ) -> None:
 
         if mn is None:
-            self.mn = np.array([0.0, 0.0])
+            self.mn = np.array([[0.0], [0.0]])
         else:
             self.mn = np.array(mn)
 
@@ -102,10 +102,20 @@ class KalmanFilterLinearRegression(TimeVaryingOnlineKalmanFilter):
         self.x, self.P = super().predict(x = self.x, P = self.P, B = self.B, Q = self.Q)
 
     def update(self, x, y):
-        self.x, self.P = super().update(y = y, x = self.x, P = self.P, Z = np.array([1, x]), R = self.R)
+        self.x, self.P = super().update(y = np.array([y]), x = self.x, P = self.P, Z = np.array([x, 1]).reshape((1, -1)), R = self.R)
     
-    def pdf(self, x1 = 0, x2 = 1, xsteps = 100, y1 = 0, y2 = 1, ysteps = 100):
-        rv = multivariate_normal(self.x, self.P)
-        x, y = np.mgrid[x1:x2:np.abs(x2-x1)/xsteps, y1:y2:np.abs(y2-y1)/ysteps]
-        pos = np.dstack((x, y))
-        self.pdf = rv.pdf(pos)
+    def pdf(self, x0 = 0, x1 = 1, xsteps = 100, y0 = 0, y1 = 1, ysteps = 100):
+
+        self.x0 = x0
+        self.x1 = x1
+        self.xsteps = xsteps
+        self.y0 = y0
+        self.y1 = y1
+        self.ysteps = ysteps
+
+        rv = multivariate_normal(self.x.flatten(), self.P)
+        self.xpos = np.linspace(x0, x1, xsteps)
+        self.ypos = np.linspace(y0, y1, ysteps)
+        xx, yy = np.meshgrid(self.xpos, self.ypos)
+        pos = np.dstack((xx, yy))
+        self.pdf_values = rv.pdf(pos)

--- a/src/Bonsai.ML.LinearDynamicalSystems/main.py
+++ b/src/Bonsai.ML.LinearDynamicalSystems/main.py
@@ -1,19 +1,6 @@
-from lds.inference import OnlineKalmanFilter
+from lds.inference import OnlineKalmanFilter, TimeVaryingOnlineKalmanFilter
 import numpy as np
-
-DEFAULT_PARAMS = {
-    "pos_x0" : 0, 
-    "pos_y0" : 0,
-    "vel_x0" : 0, 
-    "vel_y0" : 0,
-    "acc_x0" : 0, 
-    "acc_y0" : 0,
-    "sigma_a" : 10000, 
-    "sigma_x" : 100,
-    "sigma_y" : 100,
-    "sqrt_diag_V0_value" : 0.001,
-    "fps" : 60
-}
+from scipy.stats import multivariate_normal
 
 class KalmanFilterKinematics(OnlineKalmanFilter):
 
@@ -31,8 +18,6 @@ class KalmanFilterKinematics(OnlineKalmanFilter):
                     fps: int
                     ) -> None:
         
-        super(OnlineKalmanFilter, self).__init__()
-
         self.pos_x0=pos_x0
         self.pos_y0=pos_y0
         self.vel_x0=vel_x0
@@ -51,12 +36,8 @@ class KalmanFilterKinematics(OnlineKalmanFilter):
         if np.isnan(self.pos_y0):
             self.pos_y0 = 0
 
-        # build KF matrices for tracking
         dt = 1.0 / self.fps
-        # Taken from the book
-        # barShalomEtAl01-estimationWithApplicationToTrackingAndNavigation.pdf
-        # section 6.3.3
-            # Eq. 6.3.3-2
+
         B = np.array([  [1,     dt,     .5*dt**2,   0,      0,      0],
                         [0,     1,      dt,         0,      0,      0],
                         [0,     0,      1,          0,      0,      0],
@@ -64,8 +45,10 @@ class KalmanFilterKinematics(OnlineKalmanFilter):
                         [0,     0,      0,          0,      1,      dt],
                         [0,     0,      0,          0,      0,      1]],
                       dtype=np.double)
+        
         Z = np.array([  [1, 0, 0, 0, 0, 0],
                         [0, 0, 0, 1, 0, 0]],
+
                       dtype=np.double)
         Qt = np.array([ [dt**4/4,   dt**3/2,    dt**2/2,    0,          0,          0],
                         [dt**3/2,   dt**2,      dt,         0,          0,          0],
@@ -91,12 +74,38 @@ class KalmanFilterKinematics(OnlineKalmanFilter):
 
         return super().update(y=np.array([x, y]))
     
-if __name__ == "__main__":
+class KalmanFilterLinearRegression(TimeVaryingOnlineKalmanFilter):
 
-    model = KalmanFilterKinematics(**DEFAULT_PARAMS)
-    x, y = 100, 100
-    model.predict()
-    model.update(x, y)
-    print(model.x)
-    print(model.x.shape)
-    print(model.P.shape)
+    def __init__(self,
+                    likelihood_precision_coef: float,
+                    prior_precision_coef: float,
+                    mn: list[float],
+                    ) -> None:
+
+        if mn is None:
+            self.mn = np.array([0.0, 0.0])
+        else:
+            self.mn = np.array(mn)
+
+        self.likelihood_precision_coef = likelihood_precision_coef
+        self.prior_precision_coef = prior_precision_coef
+        self.x = self.mn
+        self.P = np.eye(len(self.x)) * 1.0 / self.prior_precision_coef
+
+        self.B = np.eye(N=len(self.x))
+        self.Q = np.zeros(shape=((len(self.x), len(self.x))))
+        self.R = np.array([[1.0/self.likelihood_precision_coef]])
+
+        super().__init__()
+
+    def predict(self):
+        self.x, self.P = super().predict(x = self.x, P = self.P, B = self.B, Q = self.Q)
+
+    def update(self, x, y):
+        self.x, self.P = super().update(y = y, x = self.x, P = self.P, Z = np.array([1, x]), R = self.R)
+    
+    def pdf(self, x1 = 0, x2 = 1, xsteps = 100, y1 = 0, y2 = 1, ysteps = 100):
+        rv = multivariate_normal(self.x, self.P)
+        x, y = np.mgrid[x1:x2:np.abs(x2-x1)/xsteps, y1:y2:np.abs(y2-y1)/ysteps]
+        pos = np.dstack((x, y))
+        self.pdf = rv.pdf(pos)

--- a/src/Bonsai.ML.Visualizers/Bonsai.ML.Visualizers.csproj
+++ b/src/Bonsai.ML.Visualizers/Bonsai.ML.Visualizers.csproj
@@ -5,7 +5,7 @@
     <PackageTags>Bonsai Rx ML Machine Learning Visualizers</PackageTags>
     <TargetFrameworks>net472</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.8.1" />

--- a/src/Bonsai.ML.Visualizers/Bonsai.ML.Visualizers.csproj
+++ b/src/Bonsai.ML.Visualizers/Bonsai.ML.Visualizers.csproj
@@ -5,7 +5,7 @@
     <PackageTags>Bonsai Rx ML Machine Learning Visualizers</PackageTags>
     <TargetFrameworks>net472</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.8.1" />

--- a/src/Bonsai.ML.Visualizers/ColorPalette.cs
+++ b/src/Bonsai.ML.Visualizers/ColorPalette.cs
@@ -1,6 +1,6 @@
 namespace Bonsai.ML.Visualizers
 {
-    internal enum ColorPalettes
+    internal enum ColorPalette
     {
         Cividis,
         Inferno,

--- a/src/Bonsai.ML.Visualizers/ColorPalettes.cs
+++ b/src/Bonsai.ML.Visualizers/ColorPalettes.cs
@@ -1,0 +1,20 @@
+namespace Bonsai.ML.Visualizers
+{
+    internal enum ColorPalettes
+    {
+        Cividis,
+        Inferno,
+        Viridis,
+        Magma,
+        Plasma,
+        BlackWhiteRed,
+        BlueWhiteRed,
+        Cool,
+        Gray,
+        Hot,
+        Hue,
+        HueDistinct,
+        Jet,
+        Rainbow
+    }
+}

--- a/src/Bonsai.ML.Visualizers/HeatMapSeriesOxyPlotBase.cs
+++ b/src/Bonsai.ML.Visualizers/HeatMapSeriesOxyPlotBase.cs
@@ -1,0 +1,181 @@
+using System.Windows.Forms;
+using OxyPlot;
+using OxyPlot.Series;
+using OxyPlot.WindowsForms;
+using System.Drawing;
+using System;
+using OxyPlot.Axes;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Bonsai.ML.Visualizers
+{
+    internal class HeatMapSeriesOxyPlotBase : UserControl
+    {
+        private PlotView view;
+        private PlotModel model;
+        private HeatMapSeries heatMapSeries;
+        private LinearColorAxis colorAxis;
+
+        private ComboBox comboBox;
+        private Label label;
+
+        private int _numColors = 100;
+
+        private int _selectedIndex;
+
+        private OxyPalette palette;
+
+        /// <summary>
+        /// Event handler which can be used to hook into events generated when the combobox values have changed.
+        /// </summary>
+        public event EventHandler ComboBoxValueChanged;
+
+        public ComboBox ComboBox
+        {
+            get => comboBox;
+        }
+
+        /// <summary>
+        /// Constructor of the TimeSeriesOxyPlotBase class.
+        /// Requires a line series name and an area series name.
+        /// Data source is optional, since pasing it to the constructor will populate the combobox and leave it empty otherwise.
+        /// The selected index is only needed when the data source is provided.
+        /// </summary>
+        public HeatMapSeriesOxyPlotBase(int selectedIndex, int numColors = 100)
+        {
+            _selectedIndex = selectedIndex;
+            _numColors = numColors;
+            // palette = OxyPalettes.Rainbow(_numColors);
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            view = new PlotView
+            {
+                Size = Size,
+                Dock = DockStyle.Fill,
+            };
+
+            model = new PlotModel();
+
+            heatMapSeries = new HeatMapSeries {
+                X0 = 0,
+                X1 = 100,
+                Y0 = 0,
+                Y1 = 100,
+                Interpolate = true,
+                RenderMethod = HeatMapRenderMethod.Bitmap,
+                CoordinateDefinition = HeatMapCoordinateDefinition.Center
+            };
+
+            colorAxis = new LinearColorAxis {
+                Position = AxisPosition.Right,
+            };
+
+            model.Axes.Add(colorAxis);
+            model.Series.Add(heatMapSeries);
+
+            view.Model = model;
+            Controls.Add(view);
+
+            label = new Label
+            {
+                Text = "Color palette:",
+                AutoSize = true,
+                Location = new Point(-200, 8),
+                Anchor = AnchorStyles.Top | AnchorStyles.Right
+            };
+
+            comboBox = new ComboBox
+            {
+                Location = new Point(0, 5),
+                DataSource = Enum.GetValues(typeof(ColorPalettes)),
+                Anchor = AnchorStyles.Top | AnchorStyles.Right,
+                BindingContext = BindingContext
+            };
+
+            Controls.Add(comboBox);
+            Controls.Add(label);
+
+            comboBox.SelectedIndexChanged += ComboBoxSelectedIndexChanged;
+            comboBox.SelectedIndex = _selectedIndex;
+            UpdateColorPalette();
+
+            comboBox.BringToFront();
+            label.BringToFront();
+
+            AutoScaleDimensions = new SizeF(6F, 13F);
+        }
+
+        private void ComboBoxSelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (comboBox.SelectedIndex != _selectedIndex)
+            {
+                _selectedIndex = comboBox.SelectedIndex;
+                UpdateColorPalette();
+                ComboBoxValueChanged?.Invoke(this, e);
+                UpdatePlot();
+            }
+        }
+
+        private void UpdateColorPalette()
+        {
+            var selectedPalette = (ColorPalettes)comboBox.Items[_selectedIndex];
+            paletteLookup.TryGetValue(selectedPalette, out Func<int, OxyPalette> paletteMethod);
+            palette = paletteMethod(_numColors);
+            colorAxis.Palette = palette;
+        }
+
+        public void UpdateHeatMapSeries(double x0, double x1, int xsteps, double y0, double y1, int ysteps, double[,] data)
+        {
+            heatMapSeries.X0 = x0;
+            heatMapSeries.X1 = x1;
+            heatMapSeries.Y0 = y0;
+            heatMapSeries.Y1 = y1;
+            heatMapSeries.Data = data;
+        }
+
+        public void UpdatePlot()
+        {
+            model.InvalidatePlot(true);
+        }
+
+        private static readonly Dictionary<ColorPalettes, Func<int, OxyPalette>> paletteLookup = new Dictionary<ColorPalettes, Func<int, OxyPalette>>
+        {
+            { ColorPalettes.Cividis, (numColors) => OxyPalettes.Cividis(numColors) },
+            { ColorPalettes.Inferno, (numColors) => OxyPalettes.Inferno(numColors) },
+            { ColorPalettes.Viridis, (numColors) => OxyPalettes.Viridis(numColors) },
+            { ColorPalettes.Magma, (numColors) => OxyPalettes.Magma(numColors) },
+            { ColorPalettes.Plasma, (numColors) => OxyPalettes.Plasma(numColors) },
+            { ColorPalettes.BlackWhiteRed, (numColors) => OxyPalettes.BlackWhiteRed(numColors) },
+            { ColorPalettes.BlueWhiteRed, (numColors) => OxyPalettes.BlueWhiteRed(numColors) },
+            { ColorPalettes.Cool, (numColors) => OxyPalettes.Cool(numColors) },
+            { ColorPalettes.Gray, (numColors) => OxyPalettes.Gray(numColors) },
+            { ColorPalettes.Hot, (numColors) => OxyPalettes.Hot(numColors) },
+            { ColorPalettes.Hue, (numColors) => OxyPalettes.Hue(numColors) },
+            { ColorPalettes.HueDistinct, (numColors) => OxyPalettes.HueDistinct(numColors) },
+            { ColorPalettes.Jet, (numColors) => OxyPalettes.Jet(numColors) },
+            { ColorPalettes.Rainbow, (numColors) => OxyPalettes.Rainbow(numColors) },
+        };
+    }
+
+    internal enum ColorPalettes
+    {
+        Cividis,
+        Inferno,
+        Viridis,
+        Magma,
+        Plasma,
+        BlackWhiteRed,
+        BlueWhiteRed,
+        Cool,
+        Gray,
+        Hot,
+        Hue,
+        HueDistinct,
+        Jet,
+        Rainbow
+    }
+}

--- a/src/Bonsai.ML.Visualizers/HeatMapSeriesOxyPlotBase.cs
+++ b/src/Bonsai.ML.Visualizers/HeatMapSeriesOxyPlotBase.cs
@@ -41,10 +41,7 @@ namespace Bonsai.ML.Visualizers
 
         public ToolStripComboBox RenderMethodComboBox => renderMethodComboBox;
 
-        public StatusStrip StatusStrip
-        {
-            get => statusStrip;
-        }
+        public StatusStrip StatusStrip => statusStrip;
 
         /// <summary>
         /// Constructor of the TimeSeriesOxyPlotBase class.

--- a/src/Bonsai.ML.Visualizers/HeatMapSeriesOxyPlotBase.cs
+++ b/src/Bonsai.ML.Visualizers/HeatMapSeriesOxyPlotBase.cs
@@ -35,17 +35,11 @@ namespace Bonsai.ML.Visualizers
         /// </summary>
         public event EventHandler PaletteComboBoxValueChanged;
 
-        public ToolStripComboBox PaletteComboBox
-        {
-            get => paletteComboBox;
-        }
+        public ToolStripComboBox PaletteComboBox => paletteComboBox;
 
         public event EventHandler RenderMethodComboBoxValueChanged;
 
-        public ToolStripComboBox RenderMethodComboBox
-        {
-            get => renderMethodComboBox;
-        }
+        public ToolStripComboBox RenderMethodComboBox => renderMethodComboBox;
 
         public StatusStrip StatusStrip
         {
@@ -63,7 +57,6 @@ namespace Bonsai.ML.Visualizers
             _paletteSelectedIndex = paletteSelectedIndex;
             _renderMethodSelectedIndex = renderMethodSelectedIndex;
             _numColors = numColors;
-            // palette = OxyPalettes.Rainbow(_numColors);
             Initialize();
         }
 
@@ -71,7 +64,6 @@ namespace Bonsai.ML.Visualizers
         {
             view = new PlotView
             {
-                Size = Size,
                 Dock = DockStyle.Fill,
             };
 
@@ -97,8 +89,8 @@ namespace Bonsai.ML.Visualizers
             view.Model = model;
             Controls.Add(view);
 
-            InitilizeColorPalette();
-            InitilizeRenderMethod();
+            InitializeColorPalette();
+            InitializeRenderMethod();
 
             statusStrip = new StatusStrip
             {
@@ -117,7 +109,7 @@ namespace Bonsai.ML.Visualizers
             AutoScaleDimensions = new SizeF(6F, 13F);
         }
 
-        private void InitilizeColorPalette()
+        private void InitializeColorPalette()
         {
             paletteLabel = new ToolStripLabel
             {
@@ -131,7 +123,7 @@ namespace Bonsai.ML.Visualizers
                 AutoSize = true,
             };
 
-            foreach (var value in Enum.GetValues(typeof(ColorPalettes)))
+            foreach (var value in Enum.GetValues(typeof(ColorPalette)))
             {
                 paletteComboBox.Items.Add(value);
             }
@@ -154,13 +146,13 @@ namespace Bonsai.ML.Visualizers
 
         private void UpdateColorPalette()
         {
-            var selectedPalette = (ColorPalettes)paletteComboBox.Items[_paletteSelectedIndex];
+            var selectedPalette = (ColorPalette)paletteComboBox.Items[_paletteSelectedIndex];
             paletteLookup.TryGetValue(selectedPalette, out Func<int, OxyPalette> paletteMethod);
             palette = paletteMethod(_numColors);
             colorAxis.Palette = palette;
         }
 
-        private void InitilizeRenderMethod()
+        private void InitializeRenderMethod()
         {
             renderMethodLabel = new ToolStripLabel
             {
@@ -223,22 +215,22 @@ namespace Bonsai.ML.Visualizers
             model.InvalidatePlot(true);
         }
 
-        private static readonly Dictionary<ColorPalettes, Func<int, OxyPalette>> paletteLookup = new Dictionary<ColorPalettes, Func<int, OxyPalette>>
+        private static readonly Dictionary<ColorPalette, Func<int, OxyPalette>> paletteLookup = new Dictionary<ColorPalette, Func<int, OxyPalette>>
         {
-            { ColorPalettes.Cividis, (numColors) => OxyPalettes.Cividis(numColors) },
-            { ColorPalettes.Inferno, (numColors) => OxyPalettes.Inferno(numColors) },
-            { ColorPalettes.Viridis, (numColors) => OxyPalettes.Viridis(numColors) },
-            { ColorPalettes.Magma, (numColors) => OxyPalettes.Magma(numColors) },
-            { ColorPalettes.Plasma, (numColors) => OxyPalettes.Plasma(numColors) },
-            { ColorPalettes.BlackWhiteRed, (numColors) => OxyPalettes.BlackWhiteRed(numColors) },
-            { ColorPalettes.BlueWhiteRed, (numColors) => OxyPalettes.BlueWhiteRed(numColors) },
-            { ColorPalettes.Cool, (numColors) => OxyPalettes.Cool(numColors) },
-            { ColorPalettes.Gray, (numColors) => OxyPalettes.Gray(numColors) },
-            { ColorPalettes.Hot, (numColors) => OxyPalettes.Hot(numColors) },
-            { ColorPalettes.Hue, (numColors) => OxyPalettes.Hue(numColors) },
-            { ColorPalettes.HueDistinct, (numColors) => OxyPalettes.HueDistinct(numColors) },
-            { ColorPalettes.Jet, (numColors) => OxyPalettes.Jet(numColors) },
-            { ColorPalettes.Rainbow, (numColors) => OxyPalettes.Rainbow(numColors) },
+            { ColorPalette.Cividis, (numColors) => OxyPalettes.Cividis(numColors) },
+            { ColorPalette.Inferno, (numColors) => OxyPalettes.Inferno(numColors) },
+            { ColorPalette.Viridis, (numColors) => OxyPalettes.Viridis(numColors) },
+            { ColorPalette.Magma, (numColors) => OxyPalettes.Magma(numColors) },
+            { ColorPalette.Plasma, (numColors) => OxyPalettes.Plasma(numColors) },
+            { ColorPalette.BlackWhiteRed, (numColors) => OxyPalettes.BlackWhiteRed(numColors) },
+            { ColorPalette.BlueWhiteRed, (numColors) => OxyPalettes.BlueWhiteRed(numColors) },
+            { ColorPalette.Cool, (numColors) => OxyPalettes.Cool(numColors) },
+            { ColorPalette.Gray, (numColors) => OxyPalettes.Gray(numColors) },
+            { ColorPalette.Hot, (numColors) => OxyPalettes.Hot(numColors) },
+            { ColorPalette.Hue, (numColors) => OxyPalettes.Hue(numColors) },
+            { ColorPalette.HueDistinct, (numColors) => OxyPalettes.HueDistinct(numColors) },
+            { ColorPalette.Jet, (numColors) => OxyPalettes.Jet(numColors) },
+            { ColorPalette.Rainbow, (numColors) => OxyPalettes.Rainbow(numColors) },
         };
     }
 }

--- a/src/Bonsai.ML.Visualizers/MultidimensionalArrayVisualizer.cs
+++ b/src/Bonsai.ML.Visualizers/MultidimensionalArrayVisualizer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 using System.Collections.Generic;
 using System.Reflection;
@@ -10,8 +10,10 @@ using Bonsai.ML.LinearDynamicalSystems.LinearRegression;
 using System.Drawing;
 using System.Reactive;
 using Bonsai.Reactive;
+using Bonsai.Expressions;
+using OxyPlot;
 
-[assembly: TypeVisualizer(typeof(MultivariatePDFVisualizer), Target = typeof(MultivariatePDF))]
+[assembly: TypeVisualizer(typeof(MultidimensionalArrayVisualizer), Target = typeof(double[,]))]
 
 namespace Bonsai.ML.Visualizers
 {
@@ -19,7 +21,7 @@ namespace Bonsai.ML.Visualizers
     /// <summary>
     /// Provides a type visualizer to display the state components of a Kalman Filter kinematics model.
     /// </summary>
-    public class MultivariatePDFVisualizer : DialogTypeVisualizer
+    public class MultidimensionalArrayVisualizer : DialogTypeVisualizer
     {
 
         private int paletteSelectedIndex = 0;
@@ -60,14 +62,17 @@ namespace Bonsai.ML.Visualizers
         /// <inheritdoc/>
         public override void Show(object value)
         {
-            var pdf = (MultivariatePDF)value;
+            var mdarray = (double[,])value;
+            var shape = new int[] {mdarray.GetLength(0), mdarray.GetLength(1)};
+
             Plot.UpdateHeatMapSeries(
-                pdf.GridParameters.X0 - (1 / 2 * pdf.GridParameters.Xsteps),
-                pdf.GridParameters.X1 - (1 / 2 * pdf.GridParameters.Xsteps),
-                pdf.GridParameters.Y0 - (1 / 2 * pdf.GridParameters.Ysteps),
-                pdf.GridParameters.Y1 - (1 / 2 * pdf.GridParameters.Ysteps),
-                pdf.Values
+                -0.5,
+                shape[0] - 0.5,
+                -0.5,
+                shape[1] - 0.5,
+                mdarray
             );
+
             Plot.UpdatePlot();
         }
 

--- a/src/Bonsai.ML.Visualizers/MultidimensionalArrayVisualizer.cs
+++ b/src/Bonsai.ML.Visualizers/MultidimensionalArrayVisualizer.cs
@@ -23,29 +23,23 @@ namespace Bonsai.ML.Visualizers
     /// </summary>
     public class MultidimensionalArrayVisualizer : DialogTypeVisualizer
     {
-
-        private int paletteSelectedIndex = 0;
-        private int renderMethodSelectedIndex = 0;
+        /// <summary>
+        /// Gets or sets the selected index of the color palette to use.
+        /// </summary>
+        public int PaletteSelectedIndex { get; set; }
 
         /// <summary>
-        /// Size of the window when loaded
+        /// Gets or sets the selected index of the render method to use.
         /// </summary>
-        public Size Size { get; set; } = new Size(320, 240);
-
-        /// <summary>
-        /// The selected index of the color palette to use
-        /// </summary>
-        public int PaletteSelectedIndex { get => paletteSelectedIndex; set => paletteSelectedIndex = value; }
-        public int RenderMethodSelectedIndex { get => renderMethodSelectedIndex; set => renderMethodSelectedIndex = value; }
+        public int RenderMethodSelectedIndex { get; set; }
 
         private HeatMapSeriesOxyPlotBase Plot;
 
         /// <inheritdoc/>
         public override void Load(IServiceProvider provider)
         {
-            Plot = new HeatMapSeriesOxyPlotBase(paletteSelectedIndex, renderMethodSelectedIndex)
+            Plot = new HeatMapSeriesOxyPlotBase(PaletteSelectedIndex, RenderMethodSelectedIndex)
             {
-                Size = Size,
                 Dock = DockStyle.Fill,
             };
 
@@ -85,18 +79,14 @@ namespace Bonsai.ML.Visualizers
             }
         }
 
-        /// <summary>
-        /// Callback function to update the selected index when the selected combobox index has changed
-        /// </summary>
         private void PaletteIndexChanged(object sender, EventArgs e)
         {
-            var comboBox = Plot.PaletteComboBox;
-            paletteSelectedIndex = comboBox.SelectedIndex;
+            PaletteSelectedIndex = Plot.PaletteComboBox.SelectedIndex;
         }
+        
         private void RenderMethodIndexChanged(object sender, EventArgs e)
         {
-            var comboBox = Plot.RenderMethodComboBox;
-            renderMethodSelectedIndex = comboBox.SelectedIndex;
+            RenderMethodSelectedIndex = Plot.RenderMethodComboBox.SelectedIndex;
         }
     }
 }

--- a/src/Bonsai.ML.Visualizers/MultivariatePDFVisualizer.cs
+++ b/src/Bonsai.ML.Visualizers/MultivariatePDFVisualizer.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Windows.Forms;
+using System.Collections.Generic;
+using System.Reflection;
+using Bonsai;
+using Bonsai.Design;
+using Bonsai.ML.Visualizers;
+using Bonsai.ML.LinearDynamicalSystems;
+using Bonsai.ML.LinearDynamicalSystems.LinearRegression;
+using System.Drawing;
+using System.Reactive;
+using Bonsai.Reactive;
+
+[assembly: TypeVisualizer(typeof(MultivariatePDFVisualizer), Target = typeof(MultivariatePDF))]
+
+namespace Bonsai.ML.Visualizers
+{
+
+    /// <summary>
+    /// Provides a type visualizer to display the state components of a Kalman Filter kinematics model.
+    /// </summary>
+    public class MultivariatePDFVisualizer : DialogTypeVisualizer
+    {
+
+        private int selectedIndex = 0;
+
+        /// <summary>
+        /// Size of the window when loaded
+        /// </summary>
+        public Size Size { get; set; } = new Size(320, 240);
+
+        /// <summary>
+        /// The selected index of the color palette to use
+        /// </summary>
+        public int SelectedIndex { get => selectedIndex; set => selectedIndex = value; }
+
+        private HeatMapSeriesOxyPlotBase Plot;
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            Plot = new HeatMapSeriesOxyPlotBase(selectedIndex)
+            {
+                Size = Size,
+                Dock = DockStyle.Fill,
+            };
+
+            Plot.ComboBoxValueChanged += IndexChanged;
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            if (visualizerService != null)
+            {
+                visualizerService.AddControl(Plot);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            var pdf = (MultivariatePDF)value;
+            Plot.UpdateHeatMapSeries(
+                pdf.GridParameters.X0,
+                pdf.GridParameters.X1,
+                pdf.GridParameters.Xsteps,
+                pdf.GridParameters.Y0,
+                pdf.GridParameters.Y1,
+                pdf.GridParameters.Ysteps,
+                pdf.Values
+            );
+            Plot.UpdatePlot();
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            if (!Plot.IsDisposed)
+            {
+                Plot.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Callback function to update the selected index when the selected combobox index has changed
+        /// </summary>
+        private void IndexChanged(object sender, EventArgs e)
+        {
+            var comboBox = Plot.ComboBox;
+            selectedIndex = comboBox.SelectedIndex;
+        }
+    }
+}

--- a/src/Bonsai.ML.Visualizers/MultivariatePDFVisualizer.cs
+++ b/src/Bonsai.ML.Visualizers/MultivariatePDFVisualizer.cs
@@ -21,29 +21,23 @@ namespace Bonsai.ML.Visualizers
     /// </summary>
     public class MultivariatePDFVisualizer : DialogTypeVisualizer
     {
-
-        private int paletteSelectedIndex = 0;
-        private int renderMethodSelectedIndex = 0;
+        /// <summary>
+        /// Gets or sets the selected index of the color palette to use.
+        /// </summary>
+        public int PaletteSelectedIndex { get; set; }
 
         /// <summary>
-        /// Size of the window when loaded
+        /// Gets or sets the selected index of the render method to use.
         /// </summary>
-        public Size Size { get; set; } = new Size(320, 240);
-
-        /// <summary>
-        /// The selected index of the color palette to use
-        /// </summary>
-        public int PaletteSelectedIndex { get => paletteSelectedIndex; set => paletteSelectedIndex = value; }
-        public int RenderMethodSelectedIndex { get => renderMethodSelectedIndex; set => renderMethodSelectedIndex = value; }
+        public int RenderMethodSelectedIndex { get; set; }
 
         private HeatMapSeriesOxyPlotBase Plot;
 
         /// <inheritdoc/>
         public override void Load(IServiceProvider provider)
         {
-            Plot = new HeatMapSeriesOxyPlotBase(paletteSelectedIndex, renderMethodSelectedIndex)
+            Plot = new HeatMapSeriesOxyPlotBase(PaletteSelectedIndex, RenderMethodSelectedIndex)
             {
-                Size = Size,
                 Dock = DockStyle.Fill,
             };
 
@@ -62,10 +56,10 @@ namespace Bonsai.ML.Visualizers
         {
             var pdf = (MultivariatePDF)value;
             Plot.UpdateHeatMapSeries(
-                pdf.GridParameters.X0 - (1 / 2 * pdf.GridParameters.Xsteps),
-                pdf.GridParameters.X1 - (1 / 2 * pdf.GridParameters.Xsteps),
-                pdf.GridParameters.Y0 - (1 / 2 * pdf.GridParameters.Ysteps),
-                pdf.GridParameters.Y1 - (1 / 2 * pdf.GridParameters.Ysteps),
+                pdf.GridParameters.X0 - (1 / 2 * pdf.GridParameters.XSteps),
+                pdf.GridParameters.X1 - (1 / 2 * pdf.GridParameters.XSteps),
+                pdf.GridParameters.Y0 - (1 / 2 * pdf.GridParameters.YSteps),
+                pdf.GridParameters.Y1 - (1 / 2 * pdf.GridParameters.YSteps),
                 pdf.Values
             );
             Plot.UpdatePlot();
@@ -80,18 +74,14 @@ namespace Bonsai.ML.Visualizers
             }
         }
 
-        /// <summary>
-        /// Callback function to update the selected index when the selected combobox index has changed
-        /// </summary>
         private void PaletteIndexChanged(object sender, EventArgs e)
         {
-            var comboBox = Plot.PaletteComboBox;
-            paletteSelectedIndex = comboBox.SelectedIndex;
+            PaletteSelectedIndex = Plot.PaletteComboBox.SelectedIndex;
         }
+        
         private void RenderMethodIndexChanged(object sender, EventArgs e)
         {
-            var comboBox = Plot.RenderMethodComboBox;
-            renderMethodSelectedIndex = comboBox.SelectedIndex;
+            RenderMethodSelectedIndex = Plot.RenderMethodComboBox.SelectedIndex;
         }
     }
 }

--- a/src/Bonsai.ML.Visualizers/StateComponentVisualizer.cs
+++ b/src/Bonsai.ML.Visualizers/StateComponentVisualizer.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Windows.Forms;
+using System.Collections.Generic;
+using Bonsai;
+using Bonsai.Design;
+using Bonsai.ML.Visualizers;
+using Bonsai.ML.LinearDynamicalSystems;
+using System.Drawing;
+using System.Reactive;
+
+[assembly: TypeVisualizer(typeof(StateComponentVisualizer), Target = typeof(StateComponent))]
+
+namespace Bonsai.ML.Visualizers
+{
+    /// <summary>
+    /// Provides a type visualizer to display the state components of a Kalman Filter kinematics model.
+    /// </summary>
+    public class StateComponentVisualizer : BufferedVisualizer
+    {
+
+        private DateTime? _startTime;
+
+        private TimeSeriesOxyPlotBase Plot;
+
+        /// <summary>
+        /// Size of the window when loaded
+        /// </summary>
+        public Size Size { get; set; } = new Size(320, 240);
+
+        /// <summary>
+        /// Capacity or length of time shown along the x axis of the plot during automatic updating
+        /// </summary>
+        public int Capacity { get; set; } = 10;
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            Plot = new TimeSeriesOxyPlotBase(
+                lineSeriesName: "Mean",
+                areaSeriesName: "Variance"
+            )
+            {
+                Size = Size,
+                Capacity = Capacity,
+                Dock = DockStyle.Fill,
+                StartTime = DateTime.Now
+            };
+
+            Plot.ResetSeries();
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            if (visualizerService != null)
+            {
+                visualizerService.AddControl(Plot);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override void Show(DateTime time, object value)
+        {
+            if (!_startTime.HasValue)
+            {
+                _startTime = time;
+                Plot.StartTime = _startTime.Value;
+                Plot.ResetSeries();
+            }
+
+            StateComponent stateComponent = (StateComponent)value;
+            double mean = stateComponent.Mean;
+            double variance = stateComponent.Variance;
+
+            Plot.AddToLineSeries(
+                time: time,
+                mean: mean
+            );
+
+            Plot.AddToAreaSeries(
+                time: time,
+                mean: mean,
+                variance: variance
+            );
+
+            Plot.SetAxes(minTime: time.AddSeconds(-Capacity), maxTime: time);
+
+        }
+
+        /// <inheritdoc/>
+        protected override void ShowBuffer(IList<Timestamped<object>> values)
+        {
+            base.ShowBuffer(values);
+            if (values.Count > 0)
+            {
+                Plot.UpdatePlot();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            _startTime = null;
+            if (!Plot.IsDisposed)
+            {
+                Plot.Dispose();
+            }
+        }
+    }
+}

--- a/src/Bonsai.ML.Visualizers/TimeSeriesOxyPlotBase.cs
+++ b/src/Bonsai.ML.Visualizers/TimeSeriesOxyPlotBase.cs
@@ -13,8 +13,8 @@ namespace Bonsai.ML.Visualizers
     {
         private PlotView view;
         private PlotModel model;
-        private ComboBox comboBox;
-        private Label label;
+        private ToolStripComboBox comboBox;
+        private ToolStripLabel label;
 
         private string _lineSeriesName;
         private string _areaSeriesName;
@@ -25,6 +25,8 @@ namespace Bonsai.ML.Visualizers
         private AreaSeries areaSeries;
         private Axis xAxis;
         private Axis yAxis;
+
+        private StatusStrip statusStrip;
 
         /// <summary>
         /// Event handler which can be used to hook into events generated when the combobox values have changed.
@@ -41,6 +43,16 @@ namespace Bonsai.ML.Visualizers
         /// </summary>
         public int Capacity { get; set; }
 
+        public ToolStripComboBox ComboBox
+        {
+            get => comboBox;
+        }
+
+        public StatusStrip StatusStrip
+        {
+            get => statusStrip;
+        }
+
         /// <summary>
         /// Constructor of the TimeSeriesOxyPlotBase class.
         /// Requires a line series name and an area series name.
@@ -54,11 +66,6 @@ namespace Bonsai.ML.Visualizers
             _dataSource = dataSource;
             _selectedIndex = selectedIndex;
             Initialize();
-        }
-
-        public ComboBox ComboBox
-        {
-            get => comboBox;
         }
 
         private void Initialize()
@@ -107,35 +114,57 @@ namespace Bonsai.ML.Visualizers
             view.Model = model;
             Controls.Add(view);
 
+            statusStrip = new StatusStrip
+            {
+                Visible = false
+            };
+
             if (_dataSource != null)
             {
-                label = new Label
-                {
-                    Text = "State component:",
-                    AutoSize = true,
-                    Location = new Point(-200, 8),
-                    Anchor = AnchorStyles.Top | AnchorStyles.Right
-                };
+                InitializeComboBox(_dataSource);
 
-                comboBox = new ComboBox
-                {
-                    Location = new Point(0, 5),
-                    DataSource = _dataSource,
-                    Anchor = AnchorStyles.Top | AnchorStyles.Right,
-                    BindingContext = BindingContext
-                };
+                statusStrip.Items.AddRange(new ToolStripItem[] {
+                    label,
+                    comboBox,
+                });
 
-                Controls.Add(comboBox);
-                Controls.Add(label);
-
-                comboBox.SelectedIndexChanged += ComboBoxSelectedIndexChanged;
-                comboBox.SelectedIndex = _selectedIndex;
-
-                comboBox.BringToFront();
-                label.BringToFront();
+                view.MouseClick += new MouseEventHandler(onMouseClick);
             }
 
+            Controls.Add(statusStrip);
+
             AutoScaleDimensions = new SizeF(6F, 13F);
+        }
+
+        private void onMouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                statusStrip.Visible = !statusStrip.Visible;
+            }
+        }
+
+        private void InitializeComboBox(IEnumerable dataSource)
+        {
+            label = new ToolStripLabel
+            {
+                Text = "State component:",
+                AutoSize = true,
+            };
+
+            comboBox = new ToolStripComboBox()
+            {
+                Name = "stateComponent",
+                AutoSize = true,
+            };
+
+            foreach (var value in dataSource)
+            {
+                comboBox.Items.Add(value);
+            }
+            
+            comboBox.SelectedIndexChanged += ComboBoxSelectedIndexChanged;
+            comboBox.SelectedIndex = _selectedIndex;
         }
 
         private void ComboBoxSelectedIndexChanged(object sender, EventArgs e)

--- a/src/Bonsai.ML.Visualizers/TimeSeriesOxyPlotBase.cs
+++ b/src/Bonsai.ML.Visualizers/TimeSeriesOxyPlotBase.cs
@@ -36,22 +36,16 @@ namespace Bonsai.ML.Visualizers
         /// <summary>
         /// DateTime value that determines the starting time of the data values.
         /// </summary>
-        public DateTime StartTime {get;set;}
+        public DateTime StartTime { get; set; }
 
         /// <summary>
         /// Integer value that determines how many data points should be shown along the x axis.
         /// </summary>
         public int Capacity { get; set; }
 
-        public ToolStripComboBox ComboBox
-        {
-            get => comboBox;
-        }
+        public ToolStripComboBox ComboBox => comboBox;
 
-        public StatusStrip StatusStrip
-        {
-            get => statusStrip;
-        }
+        public StatusStrip StatusStrip => statusStrip;
 
         /// <summary>
         /// Constructor of the TimeSeriesOxyPlotBase class.


### PR DESCRIPTION
This PR adds classes and workflows to the Bonsai.ML.LinearDynamicalSystems package to enable the Kalman filter to perform online linear regression. Additionally, several new visualisers were added to the Bonsai.ML.Visualizers package to allow users to visualise multidimensional arrays using OxyPlot's Heatmap.

# Linear Regression Subpackage
3 new Bonsai nodes have been added. The `KFModelParameters` node provides a class which will create the parameters needed to initialise the Kalman filter as a linear regression model. The `GridParameters` and `MultivariatePDF` nodes provide methods to modify and access the python model attributes that relate to the creation of a multivariate distribution.

3 new workflows have also been added. They allow for model creation, Bayesian inference, and computing the multivariate pdf.

# Linear Dynamical Systems Package
2 new nodes were added for manipulating 2D multidimensional arrays of double. The `Slice` operator will subsample an array using the specified start/stop indices of the desired columns/rows. The `Reshape` operator allows multidimensional arrays to be reshaped into a different number of rows/columns.

# Visualizers Package 
The `HeatMapSeriesOxyPlotBase` class provides underlying access to the `HeatMapSeries` from the OxyPlot package. Both the `MultivariatePDFVisualizer` and the `MultidimensionalArrayVisualizer` utilise this base class for visualising data.