### PR TITLE
Add forecasting capabilities to lds model

### DIFF
--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/Forecast.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/Forecast.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Collections.ObjectModel;
+using System.Xml.Serialization;
+using System.ComponentModel;
+using Newtonsoft.Json;
+using Python.Runtime;
+using System.Collections.Generic;
+
+namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
+{
+    /// <summary>
+    /// Forecasts for a Kalman Filter Kinematics python class
+    /// </summary>
+    [Combinator]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Forecasts for a Kalman Filter Kinematics (KFK) model")]
+    public class Forecast
+    {
+        private List<ForecastResult> forecastResults;
+
+        /// <summary>
+        /// list of forecast results
+        /// </summary>
+        [XmlIgnore()]
+        [JsonProperty("forecasts")]
+        [Description("list of forecast results")]
+        public List<ForecastResult> ForecastResults
+        {
+            get
+            {
+                return forecastResults;
+            }
+            private set
+            {
+                forecastResults = value;
+            }
+        }
+
+        /// <summary>
+        /// Grabs the forecasted state of a Kalman Filter model from a type of PyObject
+        /// </summary>
+        public IObservable<Forecast> Process(IObservable<PyObject> source)
+        {
+            return Observable.Select(source, pyObject => {
+
+                dynamic pyObj = pyObject;
+
+                var xs = (PyObject[])pyObj[0];
+                var Ps = (PyObject[])pyObj[1];
+                var dts = (double[])pyObj[2];
+
+                var results = new List<ForecastResult>();
+
+                for (int i = 0; i < xs.Length; i++)
+                {
+                    double[,] x = (double[,])PythonHelper.ConvertPythonObjectToCSharp(xs[i]);
+                    double[,] P = (double[,])PythonHelper.ConvertPythonObjectToCSharp(Ps[i]);
+                    var state = new State {X=x, P=P};
+                    var kinematicState = new KinematicState().Construct(state);
+
+                    var dt = dts[i];
+                    var timestep = TimeSpan.FromSeconds(dt);
+
+                    results.Add(new ForecastResult(kinematicState, timestep));
+                }
+
+                return new Forecast {
+                    ForecastResults = results
+                };
+            });
+        }
+    }
+}
+

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/Forecast.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/Forecast.cs
@@ -14,7 +14,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
     /// Represents an operator for converting forecasts from a Kalman Filter Kinematics python class into a list of forecasted results.
     /// </summary>
     [Combinator]
-    [Description("Forecasts for a Kalman Filter Kinematics (KFK) model")]
+    [Description("Forecasts for a Kalman Filter Kinematics (KFK) model.")]
     [WorkflowElementCategory(ElementCategory.Transform)]
     public class Forecast
     {

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/Forecast.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/Forecast.cs
@@ -11,35 +11,23 @@ using System.Collections.Generic;
 namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
 {
     /// <summary>
-    /// Forecasts for a Kalman Filter Kinematics python class
+    /// Represents an operator for converting forecasts from a Kalman Filter Kinematics python class into a list of forecasted results.
     /// </summary>
     [Combinator]
-    [WorkflowElementCategory(ElementCategory.Transform)]
     [Description("Forecasts for a Kalman Filter Kinematics (KFK) model")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
     public class Forecast
     {
-        private List<ForecastResult> forecastResults;
-
         /// <summary>
-        /// list of forecast results
+        /// Gets or sets the list of forecast results.
         /// </summary>
         [XmlIgnore()]
         [JsonProperty("forecasts")]
-        [Description("list of forecast results")]
-        public List<ForecastResult> ForecastResults
-        {
-            get
-            {
-                return forecastResults;
-            }
-            private set
-            {
-                forecastResults = value;
-            }
-        }
+        [Description("The list of forecast results.")]
+        public List<ForecastResult> ForecastResults { get; private set; }
 
         /// <summary>
-        /// Grabs the forecasted state of a Kalman Filter model from a type of PyObject
+        /// Converts a PyObject representing a Kalman Filter forecast into a Forecast class representing a list of forecasted results.
         /// </summary>
         public IObservable<Forecast> Process(IObservable<PyObject> source)
         {
@@ -58,7 +46,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
                     double[,] x = (double[,])PythonHelper.ConvertPythonObjectToCSharp(xs[i]);
                     double[,] P = (double[,])PythonHelper.ConvertPythonObjectToCSharp(Ps[i]);
                     var state = new State {X=x, P=P};
-                    var kinematicState = new KinematicState().Construct(state);
+                    var kinematicState = new KinematicState(state);
 
                     var dt = dts[i];
                     var timestep = TimeSpan.FromSeconds(dt);

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/ForecastResult.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/ForecastResult.cs
@@ -13,20 +13,20 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
     public class ForecastResult
     {
         /// <summary>
-        /// kinematic state
+        /// Gets or privately sets the kinematic state of the forecasted result.
         /// </summary>
         public KinematicState KinematicState { get; private set; }
 
         /// <summary>
-        /// timestep
+        /// Gets or privately sets the future time step of the forecasted result.
         /// </summary>
         public TimeSpan Timestep { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ForecastResult"/> class.
         /// </summary>
-        /// <param name="kinematicState"></param>
-        /// <param name="timestep"></param>
+        /// <param name="kinematicState">The kinematic state of the forecasted result.</param>
+        /// <param name="timestep">The future timestep of the forecasted result.</param>
         public ForecastResult(KinematicState kinematicState, TimeSpan timestep)
         {
             KinematicState = kinematicState;

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/ForecastResult.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/ForecastResult.cs
@@ -12,42 +12,18 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
     /// </summary>
     public class ForecastResult
     {
-        private KinematicState kinematicState;
-
-        private TimeSpan timestep;
-
         /// <summary>
         /// kinematic state
         /// </summary>
-        public KinematicState KinematicState
-        {
-            get
-            {
-                return kinematicState;
-            }
-            private set
-            {
-                kinematicState = value;
-            }
-        }
+        public KinematicState KinematicState { get; private set; }
 
         /// <summary>
         /// timestep
         /// </summary>
-        public TimeSpan Timestep
-        {
-            get
-            {
-                return timestep;
-            }
-            private set
-            {
-                timestep = value;
-            }
-        }
+        public TimeSpan Timestep { get; private set; }
 
         /// <summary>
-        /// Constructor of a forecast result class
+        /// Initializes a new instance of the <see cref="ForecastResult"/> class.
         /// </summary>
         /// <param name="kinematicState"></param>
         /// <param name="timestep"></param>

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/ForecastResult.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/ForecastResult.cs
@@ -1,0 +1,60 @@
+using System;
+using Newtonsoft.Json;
+using Python.Runtime;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+using System.ComponentModel;
+
+namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
+{
+    /// <summary>
+    /// Forecast result representing a collection of forecasted states at future timesteps
+    /// </summary>
+    public class ForecastResult
+    {
+        private KinematicState kinematicState;
+
+        private TimeSpan timestep;
+
+        /// <summary>
+        /// kinematic state
+        /// </summary>
+        public KinematicState KinematicState
+        {
+            get
+            {
+                return kinematicState;
+            }
+            private set
+            {
+                kinematicState = value;
+            }
+        }
+
+        /// <summary>
+        /// timestep
+        /// </summary>
+        public TimeSpan Timestep
+        {
+            get
+            {
+                return timestep;
+            }
+            private set
+            {
+                timestep = value;
+            }
+        }
+
+        /// <summary>
+        /// Constructor of a forecast result class
+        /// </summary>
+        /// <param name="kinematicState"></param>
+        /// <param name="timestep"></param>
+        public ForecastResult(KinematicState kinematicState, TimeSpan timestep)
+        {
+            KinematicState = kinematicState;
+            Timestep = timestep;
+        }
+    }
+}

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KinematicState.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KinematicState.cs
@@ -74,36 +74,39 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
             }
         }
 
-                /// <summary>
+        /// <summary>
+        /// constructor for a new KinematicState object
+        /// </summary>
+        public KinematicState Construct(State state)
+        {
+            Position = new KinematicComponent{
+                X = new StateComponent(state.X, state.P, 0),
+                Y = new StateComponent(state.X, state.P, 3),
+                Covariance = state.P[0,3]
+            };
+
+            Velocity = new KinematicComponent{
+                X = new StateComponent(state.X, state.P, 1),
+                Y = new StateComponent(state.X, state.P, 4),
+                Covariance = state.P[1,4]
+            };
+
+            Acceleration = new KinematicComponent{
+                X = new StateComponent(state.X, state.P, 2),
+                Y = new StateComponent(state.X, state.P, 5),
+                Covariance = state.P[2,5]
+            };
+            return this;
+        }
+
+        /// <summary>
         /// Converts the full state of a Kalman filter (mean vector and covariance matrix) into a KinematicState object representing position, velocity, and acceleration
         /// </summary>
         public IObservable<KinematicState> Process(IObservable<State> source)
         {
             return Observable.Select(source, state => 
             {
-                KinematicComponent position = new KinematicComponent{
-                    X = new StateComponent(state.X, state.P, 0),
-                    Y = new StateComponent(state.X, state.P, 3),
-                    Covariance = state.P[0,3]
-                };
-
-                KinematicComponent velocity = new KinematicComponent{
-                    X = new StateComponent(state.X, state.P, 1),
-                    Y = new StateComponent(state.X, state.P, 4),
-                    Covariance = state.P[1,4]
-                };
-
-                KinematicComponent acceleration = new KinematicComponent{
-                    X = new StateComponent(state.X, state.P, 2),
-                    Y = new StateComponent(state.X, state.P, 5),
-                    Covariance = state.P[2,5]
-                };
-                
-                return new KinematicState {
-                        Position = position,
-                        Velocity = velocity,
-                        Acceleration = acceleration
-                    };
+                return new KinematicState().Construct(state);
             });
         }
     }

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KinematicState.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KinematicState.cs
@@ -7,77 +7,49 @@ using Newtonsoft.Json;
 namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
 {
     /// <summary>
-    /// State of a Kalman filter model representing kinematics of position, velocity, and acceleration
+    /// Represents an operator that converts the full state of a Kalman filter model into a KinematicState class representing position, velocity, and acceleration.
     /// </summary>
-    [Description("State of a Kalman filter model representing kinematics of position, velocity, and acceleration")]
-    [Combinator()]
+    [Combinator]
+    [Description("Converts the full state of a Kalman filter model into a KinematicState representing position, velocity, and acceleration.")]
     [WorkflowElementCategory(ElementCategory.Transform)]
     public class KinematicState
-    {
-        private KinematicComponent _position;
-    
-        private KinematicComponent _velocity;
-    
-        private KinematicComponent _acceleration;
-    
+    {    
         /// <summary>
-        /// position kinematic component
+        /// Gets or sets the position kinematic component.
         /// </summary>
         [XmlIgnore()]
         [JsonProperty("position")]
-        [Description("position kinematic component")]
-        public KinematicComponent Position
-        {
-            get
-            {
-                return _position;
-            }
-            private set
-            {
-                _position = value;
-            }
-        }
+        [Description("The position kinematic component")]
+        public KinematicComponent Position { get; set; }
     
         /// <summary>
-        /// velocity kinematic components
+        /// Gets or sets the velocity kinematic component.
         /// </summary>
         [XmlIgnore()]
         [JsonProperty("velocity")]
-        [Description("velocity kinematic components")]
-        public KinematicComponent Velocity
-        {
-            get
-            {
-                return _velocity;
-            }
-            private set
-            {
-                _velocity = value;
-            }
-        }
+        [Description("THe velocity kinematic component")]
+        public KinematicComponent Velocity { get; set; }
     
         /// <summary>
-        /// acceleration kinematic components
+        /// Gets or sets the acceleration kinematic component.
         /// </summary>
         [XmlIgnore()]
         [JsonProperty("acceleration")]
-        [Description("acceleration kinematic components")]
-        public KinematicComponent Acceleration
+        [Description("The acceleration kinematic component")]
+        public KinematicComponent Acceleration { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KinematicState"/> class
+        /// </summary>
+        public KinematicState ()
         {
-            get
-            {
-                return _acceleration;
-            }
-            private set
-            {
-                _acceleration = value;
-            }
         }
 
         /// <summary>
-        /// constructor for a new KinematicState object
+        /// Initializes a new instance of the <see cref="KinematicState"/> class
+        /// from the full state of a Kalman filter model.
         /// </summary>
-        public KinematicState Construct(State state)
+        public KinematicState (State state)
         {
             Position = new KinematicComponent{
                 X = new StateComponent(state.X, state.P, 0),
@@ -96,7 +68,6 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
                 Y = new StateComponent(state.X, state.P, 5),
                 Covariance = state.P[2,5]
             };
-            return this;
         }
 
         /// <summary>
@@ -106,7 +77,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         {
             return Observable.Select(source, state => 
             {
-                return new KinematicState().Construct(state);
+                return new KinematicState(state);
             });
         }
     }

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/PerformForecasting.bonsai
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/PerformForecasting.bonsai
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:py="clr-namespace:Bonsai.Scripting.Python;assembly=Bonsai.Scripting.Python"
+                 xmlns:p1="clr-namespace:Bonsai.ML.LinearDynamicalSystems;assembly=Bonsai.ML.LinearDynamicalSystems"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p2="clr-namespace:Bonsai.ML.LinearDynamicalSystems.Kinematics;assembly=Bonsai.ML.LinearDynamicalSystems"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:ObserveOnGIL" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject" TypeArguments="p1:ModelReference">
+        <Name>model</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Name</Selector>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="Timesteps" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="IntProperty">
+          <Value>30</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:CombineLatest" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:WithLatestFrom" />
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>{0}.forecast(timesteps={1})</Format>
+        <Selector>it.Item2.Item1, it.Item2.Item2</Selector>
+      </Expression>
+      <Expression xsi:type="InputMapping">
+        <PropertyMappings>
+          <Property Name="Expression" Selector="it" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>LDSModule</Name>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="Module" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="py:Eval">
+          <py:Expression>model.forecast(timesteps=30)</py:Expression>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p2:Forecast" />
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="8" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="7" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source2" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="13" Label="Source1" />
+      <Edge From="11" To="12" Label="Source1" />
+      <Edge From="12" To="13" Label="Source2" />
+      <Edge From="13" To="14" Label="Source1" />
+      <Edge From="14" To="15" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/Bonsai.ML.LinearDynamicalSystems/PythonHelper.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/PythonHelper.cs
@@ -18,7 +18,7 @@ namespace Bonsai.ML.LinearDynamicalSystems
             return attr.As<T>();
         }
 
-        static object ConvertPythonObjectToCSharp(PyObject pyObject)
+        public static object ConvertPythonObjectToCSharp(PyObject pyObject)
         {
             if (PyInt.IsIntType(pyObject))
             {


### PR DESCRIPTION
# Summary
This PR adds forecasting capabilities to the linear dynamical systems model for kinematics.

## New classes
2 new classes were added. The `Forecast` class represents the Bonsai node that is used to convert the python model's output into a C# data structure. `Forecast` outputs a collection of `ForecastResults`. The `ForecastResult` class is the base class to represent a single forecast in time from the model, consisting of a `KinematicState` and a `Timestep`.

## Updates to existing classes
The `KinematicState` class was modified to allow easy construction of the `KinematicState` object and its properties from the full `State` object. 

## Workflows
The `PerformForecasting` workflow was added to allow easy interoperability with the python class to call the `forecast` method and convert the result to a C# `Forecast` data type. 

## Python script
The `main.py` script was modified to include a `forecast` method, which takes the timesteps as input and returns a list of forecasted states.