### PR TITLE
Added forecast visualizers

### DIFF
--- a/src/Bonsai.ML.Visualizers/Bonsai.ML.Visualizers.csproj
+++ b/src/Bonsai.ML.Visualizers/Bonsai.ML.Visualizers.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.8.1" />
     <PackageReference Include="Bonsai.Design" Version="2.8.0" />
+    <PackageReference Include="Bonsai.Vision.Design" Version="2.8.1" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="OxyPlot.Core" Version="2.1.2" />
     <PackageReference Include="OxyPlot.WindowsForms" Version="2.1.2" />
   </ItemGroup>

--- a/src/Bonsai.ML.Visualizers/ForecastImageOverlay.cs
+++ b/src/Bonsai.ML.Visualizers/ForecastImageOverlay.cs
@@ -1,0 +1,91 @@
+using Bonsai.Design;
+using Bonsai.Vision.Design;
+using Bonsai;
+using Bonsai.ML.Visualizers;
+using Bonsai.ML.LinearDynamicalSystems.Kinematics;
+using System;
+using System.Collections.Generic;
+using OpenCV.Net;
+using MathNet.Numerics.LinearAlgebra;
+using OxyPlot;
+
+[assembly: TypeVisualizer(typeof(ForecastImageOverlay), Target = typeof(MashupSource<ImageMashupVisualizer, ForecastVisualizer>))]
+
+namespace Bonsai.ML.Visualizers
+{
+    /// <summary>
+    /// Provides a mashup visualizer to display the forecast of a Kalman Filter kinematics model overtime of an ImageMashupVisualizer.
+    /// </summary>
+    public class ForecastImageOverlay : DialogTypeVisualizer
+    {
+        private ImageMashupVisualizer visualizer;
+        private IplImage overlay;
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+
+            var image = visualizer.VisualizerImage;
+            Size size = new Size(image.Width, image.Height);
+            IplDepth depth = image.Depth;
+            int channels = image.Channels;
+
+            overlay = new IplImage(size, depth, channels);
+            var alpha = 0.1;
+
+            Forecast forecast = (Forecast)value;
+            List<ForecastResult> forecastResults = forecast.ForecastResults;
+
+            for (int i = 0; i < forecastResults.Count; i++)
+            {
+                var forecastResult = forecastResults[i];
+                var kinematicState = forecastResult.KinematicState;
+
+                double xMean = kinematicState.Position.X.Mean;
+                double yMean = kinematicState.Position.Y.Mean;
+
+                Point center = new Point((int)Math.Round(xMean), (int)Math.Round(yMean));
+
+                double xVar = kinematicState.Position.X.Variance;
+                double yVar = kinematicState.Position.Y.Variance;
+                double xyCov = kinematicState.Position.Covariance;
+
+                var covariance = Matrix<double>.Build.DenseOfArray(new double[,] {
+                    { xVar, xyCov },
+                    { xyCov, yVar }
+                });
+
+                var evd = covariance.Evd();
+                var evals = evd.EigenValues.Real();
+                var evecs = evd.EigenVectors;
+
+                double angle = Math.Atan2(evecs[1, 0], evecs[0, 0]) * 180 / Math.PI;
+
+                Size axes = new Size
+                {
+                    Width = (int)(2 * Math.Sqrt(evals[0])),
+                    Height = (int)(2 * Math.Sqrt(evals[1]))
+                };
+
+                OxyColor color = OxyColors.Yellow;
+
+                CV.Ellipse(overlay, center, axes, angle, 0, 360, new Scalar(color.B, color.G, color.R, color.A), -1);
+            }
+
+            CV.AddWeighted(image, 1 - alpha, overlay, alpha, 1, image);
+            overlay.SetZero();
+        }
+        
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            visualizer = (ImageMashupVisualizer)provider.GetService(typeof(MashupVisualizer));
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            overlay.Dispose();
+        }
+    }
+}

--- a/src/Bonsai.ML.Visualizers/ForecastPlotOverlay.cs
+++ b/src/Bonsai.ML.Visualizers/ForecastPlotOverlay.cs
@@ -17,8 +17,6 @@ namespace Bonsai.ML.Visualizers
     /// </summary>
     public class ForecastPlotOverlay : DialogTypeVisualizer
     {
-        private List<StateComponentVisualizer> componentVisualizers;
-
         private List<LineSeries> lineSeriesList = new();
 
         private List<AreaSeries> areaSeriesList = new();
@@ -30,6 +28,7 @@ namespace Bonsai.ML.Visualizers
         {
             var time = DateTime.Now;
             Forecast forecast = (Forecast)value;
+            var componentVisualizers = visualizer.componentVisualizers;
 
             for (int i = 0; i < componentVisualizers.Count; i++)
             {
@@ -80,9 +79,21 @@ namespace Bonsai.ML.Visualizers
         /// <inheritdoc/>
         public override void Load(IServiceProvider provider)
         {
+            if (lineSeriesList.Count > 0)
+            {
+                lineSeriesList.Clear();
+                lineSeriesList = new();
+            }
+
+            if (areaSeriesList.Count > 0)
+            {
+                areaSeriesList.Clear();
+                areaSeriesList = new();
+            }
+
             var service = provider.GetService(typeof(MashupVisualizer));
             visualizer = (KinematicStateVisualizer)service;
-            componentVisualizers = visualizer.componentVisualizers;
+            var componentVisualizers = visualizer.componentVisualizers;
 
             for (int i = 0; i < componentVisualizers.Count; i++)
             {

--- a/src/Bonsai.ML.Visualizers/ForecastPlotOverlay.cs
+++ b/src/Bonsai.ML.Visualizers/ForecastPlotOverlay.cs
@@ -1,0 +1,91 @@
+using Bonsai.Design;
+using Bonsai;
+using Bonsai.ML.Visualizers;
+using Bonsai.ML.LinearDynamicalSystems;
+using Bonsai.ML.LinearDynamicalSystems.Kinematics;
+using System;
+using System.Collections.Generic;
+using OxyPlot.Series;
+using OxyPlot;
+
+[assembly: TypeVisualizer(typeof(ForecastPlotOverlay), Target = typeof(MashupSource<KinematicStateVisualizer, ForecastVisualizer>))]
+
+namespace Bonsai.ML.Visualizers
+{
+    /// <summary>
+    /// Provides a mashup visualizer to display the forecast of a Kalman Filter kinematics model overtime of a KinematicStateVisualizer.
+    /// </summary>
+    public class ForecastPlotOverlay : DialogTypeVisualizer
+    {
+        private TimeSeriesOxyPlotBase plot;
+
+        private LineSeries lineSeries;
+
+        private AreaSeries areaSeries;
+
+        private KinematicStateVisualizer visualizer;
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            var time = DateTime.Now;
+            plot.ResetLineSeries(lineSeries);
+            plot.ResetAreaSeries(areaSeries);
+
+            Forecast forecast = (Forecast)value;
+            List<ForecastResult> forecastResults = forecast.ForecastResults;
+            DateTime forecastTime = time;
+
+            for (int i = 0; i < forecastResults.Count; i++)
+            {
+                var forecastResult = forecastResults[i];
+                var kinematicState = forecastResult.KinematicState;
+
+                forecastTime = time + forecastResult.Timestep;
+
+                KinematicComponent kinematicComponent = (KinematicComponent)visualizer.kinematicComponentProperty.GetValue(kinematicState);
+                StateComponent stateComponent = (StateComponent)visualizer.stateComponentProperty.GetValue(kinematicComponent);
+
+                double mean = stateComponent.Mean;
+                double variance = stateComponent.Variance;
+
+                plot.AddToLineSeries(
+                    lineSeries: lineSeries,
+                    time: forecastTime,
+                    value: mean
+                );
+
+                plot.AddToAreaSeries(
+                    areaSeries: areaSeries,
+                    time: forecastTime,
+                    value1: mean + variance,
+                    value2: mean - variance
+                );
+            }
+
+            plot.SetAxes(minTime: forecastTime.AddSeconds(-plot.Capacity), maxTime: forecastTime);
+        }
+        
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            var service = provider.GetService(typeof(MashupVisualizer));
+            visualizer = (KinematicStateVisualizer)service;
+            plot = visualizer.Plot;
+
+            lineSeries = plot.AddNewLineSeries("Forecast Mean", color: OxyColors.Yellow);
+            areaSeries = plot.AddNewAreaSeries("Forecast Variance", color: OxyColors.Yellow, opacity: 50);
+
+            plot.ResetLineSeries(lineSeries);
+            plot.ResetAreaSeries(areaSeries);
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            plot.ResetLineSeries(lineSeries);
+            plot.ResetAreaSeries(areaSeries);
+        }
+
+    }
+}

--- a/src/Bonsai.ML.Visualizers/ForecastPlotOverlay.cs
+++ b/src/Bonsai.ML.Visualizers/ForecastPlotOverlay.cs
@@ -28,7 +28,7 @@ namespace Bonsai.ML.Visualizers
         {
             var time = DateTime.Now;
             Forecast forecast = (Forecast)value;
-            var componentVisualizers = visualizer.componentVisualizers;
+            var componentVisualizers = visualizer.ComponentVisualizers;
 
             for (int i = 0; i < componentVisualizers.Count; i++)
             {
@@ -93,7 +93,7 @@ namespace Bonsai.ML.Visualizers
 
             var service = provider.GetService(typeof(MashupVisualizer));
             visualizer = (KinematicStateVisualizer)service;
-            var componentVisualizers = visualizer.componentVisualizers;
+            var componentVisualizers = visualizer.ComponentVisualizers;
 
             for (int i = 0; i < componentVisualizers.Count; i++)
             {

--- a/src/Bonsai.ML.Visualizers/ForecastVisualizer.cs
+++ b/src/Bonsai.ML.Visualizers/ForecastVisualizer.cs
@@ -20,9 +20,9 @@ namespace Bonsai.ML.Visualizers
     public class ForecastVisualizer : BufferedVisualizer
     {
 
-        internal int RowCount { get; set; } = 3;
-        internal int ColumnCount { get; set; } = 2;
-        internal string[] Labels = new string[] { 
+        private int rowCount = 3;
+        private int columnCount = 2;
+        private string[] labels = new string[] { 
             "Forecast Position X", 
             "Forecast Position Y", 
             "Forecast Velocity X", 
@@ -31,7 +31,7 @@ namespace Bonsai.ML.Visualizers
             "Forecast Acceleration Y" 
         };
 
-        internal List<StateComponentVisualizer> componentVisualizers = new();
+        private List<StateComponentVisualizer> componentVisualizers = new();
         private TableLayoutPanel container;
 
         /// <inheritdoc/>
@@ -39,27 +39,27 @@ namespace Bonsai.ML.Visualizers
         {
             container = new TableLayoutPanel
             {
-                ColumnCount = ColumnCount,
-                RowCount = RowCount,
+                ColumnCount = columnCount,
+                RowCount = rowCount,
                 Dock = DockStyle.Fill
             };
 
             for (int i = 0; i < container.RowCount; i++)
             {
-                container.RowStyles.Add(new RowStyle(SizeType.Percent, 100f / RowCount));
+                container.RowStyles.Add(new RowStyle(SizeType.Percent, 100f / rowCount));
             }
 
             for (int i = 0; i < container.ColumnCount; i++)
             {
-                container.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f / ColumnCount));
+                container.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f / columnCount));
             }
 
-            for (int i = 0 ; i < RowCount; i++)
+            for (int i = 0 ; i < rowCount; i++)
             {
-                for (int j = 0; j < ColumnCount; j++)
+                for (int j = 0; j < columnCount; j++)
                 {
                     var StateComponentVisualizer = new StateComponentVisualizer() {
-                        Label = Labels[i * ColumnCount + j],
+                        Label = labels[i * columnCount + j],
                         LineSeriesColor = OxyColors.Yellow,
                         AreaSeriesColor = OxyColors.Yellow
                     };
@@ -115,8 +115,8 @@ namespace Bonsai.ML.Visualizers
 
             foreach (var item in zippedData)
             {
-                item.Visualizer.Plot.ResetLineSeries(item.Visualizer.lineSeries);
-                item.Visualizer.Plot.ResetAreaSeries(item.Visualizer.areaSeries);
+                item.Visualizer.Plot.ResetLineSeries(item.Visualizer.LineSeries);
+                item.Visualizer.Plot.ResetAreaSeries(item.Visualizer.AreaSeries);
                 item.Visualizer.ShowDataBuffer(item.Data);
                 item.Visualizer.Plot.SetAxes(minTime: timestamp.DateTime, maxTime: futureTime.DateTime);
             }

--- a/src/Bonsai.ML.Visualizers/ForecastVisualizer.cs
+++ b/src/Bonsai.ML.Visualizers/ForecastVisualizer.cs
@@ -5,9 +5,7 @@ using Bonsai;
 using Bonsai.Design;
 using Bonsai.ML.Visualizers;
 using Bonsai.ML.LinearDynamicalSystems.Kinematics;
-using System.Drawing;
 using OxyPlot;
-using OxyPlot.Series;
 using System.Reactive;
 using System.Linq;
 using System.Reactive.Linq;
@@ -91,6 +89,7 @@ namespace Bonsai.ML.Visualizers
             var latestForecast = values.Last();
             var timestamp = latestForecast.Timestamp;
             var forecast = (Forecast)latestForecast.Value;
+            var futureTime = timestamp;
 
             List<Timestamped<object>> positionX = new();
             List<Timestamped<object>> positionY = new();
@@ -101,7 +100,7 @@ namespace Bonsai.ML.Visualizers
 
             foreach (var forecastResult in forecast.ForecastResults)
             {
-                var futureTime = timestamp + forecastResult.Timestep;
+                futureTime = timestamp + forecastResult.Timestep;
                 positionX.Add(new Timestamped<object>(forecastResult.KinematicState.Position.X, futureTime));
                 positionY.Add(new Timestamped<object>(forecastResult.KinematicState.Position.Y, futureTime));
                 velocityX.Add(new Timestamped<object>(forecastResult.KinematicState.Velocity.X, futureTime));
@@ -119,6 +118,7 @@ namespace Bonsai.ML.Visualizers
                 item.Visualizer.Plot.ResetLineSeries(item.Visualizer.lineSeries);
                 item.Visualizer.Plot.ResetAreaSeries(item.Visualizer.areaSeries);
                 item.Visualizer.ShowDataBuffer(item.Data);
+                item.Visualizer.Plot.SetAxes(minTime: timestamp.DateTime, maxTime: futureTime.DateTime);
             }
         }
 

--- a/src/Bonsai.ML.Visualizers/ForecastVisualizer.cs
+++ b/src/Bonsai.ML.Visualizers/ForecastVisualizer.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Windows.Forms;
+using System.Collections.Generic;
+using Bonsai;
+using Bonsai.Design;
+using Bonsai.ML.Visualizers;
+using Bonsai.ML.LinearDynamicalSystems.Kinematics;
+using System.Drawing;
+using OxyPlot;
+using OxyPlot.Series;
+
+[assembly: TypeVisualizer(typeof(ForecastVisualizer), Target = typeof(Forecast))]
+
+namespace Bonsai.ML.Visualizers
+{
+    /// <summary>
+    /// Provides a type visualizer to display the forecast of a Kalman Filter kinematics model.
+    /// </summary>
+    public class ForecastVisualizer : DialogTypeVisualizer
+    {
+
+        private DateTime? _startTime;
+        private DateTime? lastUpdate = null;
+
+        private TimeSeriesOxyPlotBase Plot;
+        private LineSeries lineSeries;
+        private AreaSeries areaSeries;
+
+        /// <summary>
+        /// Update frequency of the plot
+        /// </summary>
+        public TimeSpan UpdateFrequency { get; set; } = TimeSpan.FromSeconds(1/30);
+
+        /// <summary>
+        /// Size of the window when loaded
+        /// </summary>
+        public Size Size { get; set; } = new Size(320, 240);
+
+        /// <summary>
+        /// Capacity or length of time shown along the x axis of the plot during automatic updating
+        /// </summary>
+        public int Capacity { get; set; } = 10;
+
+        /// <summary>
+        /// Buffer the data beyond the capacity
+        /// </summary>
+        public bool BufferData { get; set; } = true;
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            Plot = new TimeSeriesOxyPlotBase()
+            {
+                Size = Size,
+                Capacity = Capacity,
+                Dock = DockStyle.Fill,
+                StartTime = DateTime.Now,
+                BufferData = BufferData,
+            };
+
+            lineSeries = Plot.AddNewLineSeries("Forecast Mean", color: OxyColors.Yellow);
+            areaSeries = Plot.AddNewAreaSeries("Forecast Variance", color: OxyColors.Yellow);
+
+            Plot.ResetAxes();
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            if (visualizerService != null)
+            {
+                visualizerService.AddControl(Plot);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            var time = DateTime.Now;
+            if (!_startTime.HasValue)
+            {
+                _startTime = time;
+                Plot.StartTime = _startTime.Value;
+                Plot.ResetAxes();
+            }
+
+            Plot.ResetLineSeries(lineSeries);
+            Plot.ResetAreaSeries(areaSeries);
+
+            Forecast forecast = (Forecast)value;
+            List<ForecastResult> forecastResults = forecast.ForecastResults;
+            DateTime forecastTime = time;
+
+            for (int i = 0; i < forecastResults.Count; i++)
+            {
+                var forecastResult = forecastResults[i];
+                var kinematicState = forecastResult.KinematicState;
+
+                forecastTime = time + forecastResult.Timestep;
+                double mean = kinematicState.Position.X.Mean;
+                double variance = kinematicState.Position.X.Variance;
+
+                Plot.AddToLineSeries(
+                    lineSeries: lineSeries,
+                    time: forecastTime,
+                    value: mean
+                );
+
+                Plot.AddToAreaSeries(
+                    areaSeries: areaSeries,
+                    time: forecastTime,
+                    value1: mean + variance,
+                    value2: mean - variance
+                );
+            }
+
+            Plot.SetAxes(minTime: forecastTime.AddSeconds(-Capacity), maxTime: forecastTime);
+
+            if (lastUpdate is null || time - lastUpdate > UpdateFrequency)
+            {
+                lastUpdate = time;
+                Plot.UpdatePlot();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            _startTime = null;
+            if (!Plot.IsDisposed)
+            {
+                Plot.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary
This PR adds support for visualizing forecasts. This adds both a base visualizer called `ForecastVisualizer`, as well as mashup visualizers to observe the forecast in relation to the KinematicState timeseries plot `ForecastPlotOverlay` and an image being tracked `ForecastImageOverlay`.