### PR TITLE
Refactor build solution jobs into CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          submodules: true
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+        
+      - name: Restore NuGet Packages
+        run: msbuild -t:restore src/Bonsai.ML.sln
+
+      - name: Build Solution
+        run: msbuild src/Bonsai.ML.sln /p:Configuration=Release

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,27 +5,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build_docs:
     runs-on: windows-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.1
-        with:
-          submodules: true
+      - name: Build Solution
+        uses: ./.github/workflows/build.yml
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: 7.x
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-        
-      - name: Restore NuGet Packages
-        run: msbuild -t:restore src/Bonsai.ML.sln
-
-      - name: Build Solution
-        run: msbuild src/Bonsai.ML.sln /p:Configuration=Release
         
       - name: Setup DocFX
         run: dotnet tool restore


### PR DESCRIPTION
To accelerate integration testing of parallel PRs it would be useful to have a CI pipeline for building and testing whether the solution builds for each PR in advance of review.

As a first step, this PR simply refactors the basic build steps used for documentation deployment into a separate reusable workflow, as described in [Reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows). We can later add unit tests or running with examples as additional steps.