### PR TITLE
Avoid shutdown exception due to deprecated API

### DIFF
--- a/tests/Bonsai.ML.LinearDynamicalSystems.Tests/Bonsai.ML.LinearDynamicalSystems.Tests.csproj
+++ b/tests/Bonsai.ML.LinearDynamicalSystems.Tests/Bonsai.ML.LinearDynamicalSystems.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
PythonEngine shutdown currently relies on BinaryFormatter which has been deprecated with .NET 8. This is a known issue documented at: https://github.com/pythonnet/pythonnet/issues/2282.