### PR TITLE
Allow examples to bootstrap from local packages

### DIFF
--- a/docs/NuGet.config
+++ b/docs/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="Build Packages" value="../src/bin/Release" />
+  </packageSources>
+</configuration>

--- a/src/Bonsai.ML.LinearDynamicalSystems/Properties/launchSettings.json
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "executablePath": "$(SolutionDir)\\.bonsai\\Bonsai.exe",
       "commandLineArgs": "--lib:\"$(TargetDir).\"",
       "nativeDebugging": true
     }

--- a/src/Bonsai.ML.Visualizers/Properties/launchSettings.json
+++ b/src/Bonsai.ML.Visualizers/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "executablePath": "$(SolutionDir)\\.bonsai\\Bonsai.exe",
       "commandLineArgs": "--lib:\"$(TargetDir).\"",
       "nativeDebugging": true
     }

--- a/src/Bonsai.ML/Properties/launchSettings.json
+++ b/src/Bonsai.ML/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "executablePath": "$(SolutionDir)\\.bonsai\\Bonsai.exe",
       "commandLineArgs": "--lib:\"$(TargetDir).\"",
       "nativeDebugging": true
     }


### PR DESCRIPTION
Currently bootstrapping the examples submodule depends on having publicly available NuGet packages. This PR adds a `NuGet.config` to the root of the `docs` folder so that we can use packages built locally to bootstrap the example environments.

This should allow working with the submodule directly from this repo before publishing a new package version, for instance when trying out the examples before release.

Finally, we have also updated launch targets to use the local environment for package debugging, for consistency with the workflow used for generating documentation assets, e.g. images and to avoid relying on system-wide installs.