### PR TITLE
Use state component visualizer label in Y axis

### DIFF
--- a/src/Bonsai.ML.Visualizers/StateComponentVisualizer.cs
+++ b/src/Bonsai.ML.Visualizers/StateComponentVisualizer.cs
@@ -71,6 +71,7 @@ namespace Bonsai.ML.Visualizers
             var areaSeriesName = string.IsNullOrEmpty(Label) ? "Variance" : $"{Label} Variance";
             AreaSeries = Plot.AddNewAreaSeries(areaSeriesName, color: AreaSeriesColor);
 
+            if (Label != null) Plot.ValueLabel = Label;
             Plot.ResetLineSeries(LineSeries);
             Plot.ResetAreaSeries(AreaSeries);
             Plot.ResetAxes();

--- a/src/Bonsai.ML.Visualizers/TimeSeriesOxyPlotBase.cs
+++ b/src/Bonsai.ML.Visualizers/TimeSeriesOxyPlotBase.cs
@@ -11,15 +11,15 @@ namespace Bonsai.ML.Visualizers
 {
     internal class TimeSeriesOxyPlotBase : UserControl
     {
-        private PlotView view;
-        private PlotModel model;
-        private OxyColor defaultLineSeriesColor = OxyColors.Blue;
-        private OxyColor defaultAreaSeriesColor = OxyColors.LightBlue;
+        private readonly PlotView view;
+        private readonly PlotModel model;
+        private static readonly OxyColor defaultLineSeriesColor = OxyColors.Blue;
+        private static readonly OxyColor defaultAreaSeriesColor = OxyColors.LightBlue;
 
-        private Axis xAxis;
-        private Axis yAxis;
+        private readonly Axis xAxis;
+        private readonly Axis yAxis;
 
-        private StatusStrip statusStrip;
+        private readonly StatusStrip statusStrip;
 
         /// <summary>
         /// Gets or sets the datetime value that determines the starting time of the data values.
@@ -42,14 +42,18 @@ namespace Bonsai.ML.Visualizers
         public bool BufferData { get; set; }
 
         /// <summary>
+        /// Gets or sets the label of the value axis in the time series plot.
+        /// </summary>
+        public string ValueLabel
+        {
+            get => yAxis.Title;
+            set => yAxis.Title = value;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TimeSeriesOxyPlotBase"/> class
         /// </summary>
         public TimeSeriesOxyPlotBase()
-        {
-            Initialize();
-        }
-
-        private void Initialize()
         {
             view = new PlotView
             {


### PR DESCRIPTION
`StateComponentVisualizer` currently allows specifying an optional label to use in line and area series names. This PR refactors the time series plots so that we can use this label also in the Y axis, to improve readability when creating tabular grids of multiple plots.

Fixes #19 