### PR TITLE
Update and optimize ML operator icon

### DIFF
--- a/elementIcon.svg
+++ b/elementIcon.svg
@@ -1,58 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   width="29mm"
-   height="29mm"
-   viewBox="0 0 29 28.999999"
-   version="1.1"
-   id="svg1"
-   xml:space="preserve"
-   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
-   sodipodi:docname="Bonsai.ML.LinearDynamicalSystems4.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
-     id="namedview1"
-     pagecolor="#1100ff"
-     bordercolor="#ffffff"
-     borderopacity="1"
-     inkscape:showpageshadow="0"
-     inkscape:pageopacity="0"
-     inkscape:pagecheckerboard="true"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm"
-     showguides="false"
-     inkscape:zoom="2.5953041"
-     inkscape:cx="39.687064"
-     inkscape:cy="78.025539"
-     inkscape:window-width="1280"
-     inkscape:window-height="715"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="g1"
-     showborder="true"
-     inkscape:clip-to-page="false" /><defs
-     id="defs1" /><g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1"
-     style="display:inline;stroke:#000000;stroke-opacity:1"
-     transform="translate(0.82635664,3.178795)"><g
-       id="g1"
-       transform="translate(0.71365754,1.8496201)"><path
-         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.351189;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-         d="M 11.317902,21.723175 C 8.7566013,20.9618 8.1938223,22.284264 6.9111883,19.700699 c 1.464522,-0.15712 2.899615,-0.475529 4.4067137,2.022476 z"
-         id="path12-9-0-5"
-         sodipodi:nodetypes="ccc" /><path
-         id="path1"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.19432;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
-         d="m 13.057378,-1.7279002 5.17e-4,5.167e-4 c -0.878029,-1.92e-5 -1.590103,0.7120532 -1.590084,1.59008383 5.64e-4,0.4529904 0.194436,0.8837412 0.532784,1.18494057 l -0.675411,0.6759278 v 2.499589 H 9.6363976 L 8.6581627,3.2454396 C 9.06866,2.9473438 9.3123893,2.4711789 9.3139366,1.9638641 9.3139557,1.0858346 8.6018833,0.37376113 7.7238528,0.37378023 6.8458625,0.37381633 6.1342666,1.085874 6.1342857,1.9638641 6.1358657,2.5343183 6.442831,3.0598696 6.9388878,3.3415578 L 9.128935,5.531605 h 2.196249 V 8.7531138 H 9.4462283 C 9.3122067,8.4901135 9.0417097,8.3242648 8.7465294,8.3241994 c -0.433628,7.9e-6 -0.7849571,0.3513369 -0.784965,0.7849648 7.9e-6,0.433627 0.3513381,0.785473 0.784965,0.785482 0.1866051,-1.51e-4 0.3670573,-0.06698 0.5090129,-0.188102 H 11.325184 V 13.956414 H 7.5605553 L 6.8226158,12.678456 c 0.029246,-0.118795 0.044675,-0.240439 0.045992,-0.362769 C 6.8685721,11.437694 6.157032,10.7261 5.2790408,10.72612 4.4010507,10.7261 3.688993,11.437694 3.688957,12.315687 c -2.03e-5,0.878038 0.7120543,1.590096 1.5900838,1.590084 0.3145451,-5.86e-4 0.6214947,-0.09493 0.8826335,-0.270268 l 0.8304402,1.438672 h 4.3330695 v 6.654374 h 1.845883 v -3.224092 h 0.05323 l 3.271118,-1.888774 c 0.37858,-0.160721 0.402043,-0.540298 0.402043,-0.648023 h 1.327051 c 0.249447,0.585246 0.824184,0.965359 1.460376,0.96635 0.877993,-3.3e-5 1.58959,-0.712092 1.589567,-1.590084 -3.4e-5,-0.877948 -0.711608,-1.589533 -1.589567,-1.589567 -0.63751,0.0011 -1.212852,0.382919 -1.46141,0.969967 H 16.753798 C 16.578201,14.443718 16.270895,14.2728 15.939894,14.27164 c -0.532442,3.4e-5 -0.964304,0.431852 -0.964282,0.964282 3.94e-4,0.226014 0.08005,0.44437 0.225309,0.617534 l -2.020549,1.166853 v -4.471045 l 5.96191,-3.4421668 c 7.77e-4,6.8e-5 8.34e-4,-5.8e-5 0.0021,0 0.278401,-0.0091 0.522407,-0.188565 0.613916,-0.4516519 h 1.91978 c 0.293198,0.2732589 0.678723,0.4257619 1.07952,0.4268479 0.877993,1.9e-5 1.590049,-0.7115717 1.590084,-1.5895676 2.2e-5,-0.8780352 -0.712046,-1.590103 -1.590084,-1.5900838 -0.877992,3.6e-5 -1.589579,0.712087 -1.589567,1.5900838 5.85e-4,0.00924 8.34e-4,0.018637 0.0021,0.027905 h -1.461926 l -0.01034,-4.8519003 c 0.576686,-0.2535801 0.949194,-0.8236816 0.949813,-1.4536581 2.2e-5,-0.87803507 -0.71153,-1.58958729 -1.589567,-1.58956699 -0.878027,-2.03e-5 -1.590106,0.71153072 -1.590084,1.58956699 0.0011,0.6479617 0.396545,1.230365 0.997872,1.4717449 v 5.5743367 l -5.965528,3.4442342 -0.0041,-0.0047 V 2.5906992 l 1.356507,-1.3559897 c 0.490449,-0.28329057 0.792802,-0.80614507 0.794266,-1.37252597 2.2e-5,-0.87799103 -0.711563,-1.59004883 -1.589567,-1.59008373 z" /><rect
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1"
-         id="rect2"
-         width="0.54334724"
-         height="3.6816683"
-         x="13.048687"
-         y="18.047735" /></g></g></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30" height="30" version="1.1" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
+ <path d="m17.669 23.046-3.1412-8.6569 8.9426 2.4421" fill="none" stroke="#fff" stroke-width="1.2"/>
+ <path d="m8.3192 8.979 6.2081 5.4771 4.6078-7.5026-10.816 2.0255-1.7891 8.9927 7.9972-3.5156" fill="none" stroke="#fff" stroke-width="1.2"/>
+ <g fill="#fff" fill-rule="evenodd">
+  <circle cx="19.135" cy="6.9536" r="2.4"/>
+  <circle cx="22.754" cy="16.585" r="2.4"/>
+  <circle cx="17.669" cy="23.046" r="2.4"/>
+  <circle cx="6.5301" cy="17.972" r="2.4"/>
+  <circle cx="8.3192" cy="8.979" r="2.4"/>
+  <circle cx="14.527" cy="14.456" r="2.4"/>
+ </g>
+</svg>


### PR DESCRIPTION
This PR is a redesign of the default operator icon to follow the standard library icon design guidelines. A copy of the icon source has also been deposited in [bonsai-rx/bonsai-icons](https://github.com/bonsai-rx/bonsai-icons).

In the future, this icon may move to the standard library so it can be reused more easily across different ML packages.