### PR TITLE
Fix lds mashups

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <IncludeSymbols>true</IncludeSymbols>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>

--- a/src/Bonsai.ML.LinearDynamicalSystems.Design/ForecastImageOverlay.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems.Design/ForecastImageOverlay.cs
@@ -8,7 +8,7 @@ using OpenCV.Net;
 using OxyPlot;
 
 [assembly: TypeVisualizer(typeof(Bonsai.ML.LinearDynamicalSystems.Design.ForecastImageOverlay),
-    Target = typeof(Bonsai.ML.LinearDynamicalSystems.Kinematics.Forecast))]
+    Target = typeof(MashupSource<ImageMashupVisualizer, Bonsai.ML.LinearDynamicalSystems.Design.ForecastVisualizer>))]
 
 namespace Bonsai.ML.LinearDynamicalSystems.Design
 {

--- a/src/Bonsai.ML.LinearDynamicalSystems.Design/ForecastPlotOverlay.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems.Design/ForecastPlotOverlay.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using OxyPlot.Series;
 using OxyPlot;
 
-[assembly: TypeVisualizer(typeof(Bonsai.ML.LinearDynamicalSystems.Design.ForecastImageOverlay),
+[assembly: TypeVisualizer(typeof(Bonsai.ML.LinearDynamicalSystems.Design.ForecastPlotOverlay),
     Target = typeof(MashupSource<Bonsai.ML.LinearDynamicalSystems.Design.KinematicStateVisualizer, Bonsai.ML.LinearDynamicalSystems.Design.ForecastVisualizer>))]
 
 namespace Bonsai.ML.LinearDynamicalSystems.Design


### PR DESCRIPTION
This PR fixes the issues with the mashup type visualizers in the Bonsai.ML.LinearDynamicalSystems.Design project. More specifically, the types used in the type visualizer attribute were fixed to their correct targets.