### PR TITLE
Fix unnecessary GitHub Actions version specificity, update old actions, and update to modern GitHub Pages deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4.0.0
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.x
-        
+
       - name: Restore NuGet Packages
         run: dotnet restore Bonsai.ML.sln
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,17 @@
-# Builds and publishes the documentation website to gh-pages branch
+# Builds and publishes the documentation website
 name: Build docs
 
 on:
   workflow_dispatch:
+
+concurrency:
+  group: docs
+  cancel-in-progress: true
+
+permissions:
+  # Both required by actions/deploy-pages
+  pages: write
+  id-token: write
 
 jobs:
   build_docs:
@@ -14,31 +23,31 @@ jobs:
           submodules: true
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4.0.0
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.x
-        
+
       - name: Restore NuGet Packages
         run: dotnet restore Bonsai.ML.sln
 
       - name: Build Solution
         run: dotnet build Bonsai.ML.sln -c Release
-        
+
       - name: Setup DocFX
         run: dotnet tool restore
 
       - name: Setup Bonsai
         working-directory: .bonsai
         run: ./Setup.ps1
-        
+
       - name: Build Documentation
         working-directory: docs
         run: ./build.ps1
 
-      - name: Publish to github pages
-        uses: peaceiris/actions-gh-pages@v3.9.3
+      - name: Upload GitHub Pages Artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_site
-          publish_branch: gh-pages
-          force_orphan: true
+          path: docs/_site
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,15 @@ jobs:
           submodules: true
 
       - name: Setup Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.10
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4.0.0
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.x
-        
+
       - name: Restore NuGet Packages
         run: dotnet restore Bonsai.ML.sln
 


### PR DESCRIPTION
I am opening this PR as a draft because I was unable to verify the proper operation of the `docs` and `test` workflows. This appears to be due to unrelated to these changes, but I wanted to note the issue. (At a glance, some of the problems related to https://github.com/bonsai-rx/machinelearning/issues/31 are a likely culprit.)

This PR can probably be safely merged as-is (the affected workflows are only manually run) and these issues can be resolved later, but the GitHub Pages deployment source should probably not be updated until the `docs` workflow is working again.

------------

~~**Before merging this PR:** Go to [the GitHub Pages settings](../settings/pages) for this repo and change the build/deployment source to "GitHub Actions".~~ (This *is* necessary, but see note above.)

------------

This PR removes unnecessary version specificity for actions used in GitHub Actions workflows in this repository. This reflects best practices and avoids upcoming issues with `actions/setup-dotnet`, see [this issue](https://github.com/bonsai-rx/bonsai/issues/2091) for details.

While I was at it I migrated the docs workflow to use the modern method for GitHub Pages deployment, and updated other actions as appropriate.