### PR TITLE
Update Directory Build props with artifacts output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Packages
 *.exe.settings
 *.exe.old
 *.dll
+artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 .vs
 .venv
-bin
-obj
 Packages
 *.orig
 *.user
@@ -10,4 +8,4 @@ Packages
 *.exe.settings
 *.exe.old
 *.dll
-artifacts
+/artifacts/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <PackageProjectUrl>https://bonsai-rx.org/machinelearning</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bonsai-rx/machinelearning.git</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -17,6 +16,7 @@
     <VersionPrefix>0.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>12.0</LangVersion>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="..\..\LICENSE" PackagePath="/" />

--- a/docs/NuGet.config
+++ b/docs/NuGet.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="Build Packages" value="../src/bin/Release" />
+    <add key="Build Packages" value="../artifacts/package/release" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This pull request includes updates to the `Directory.Build.props` file to enhance the build configuration and output management. The most important changes include removing the `PackageOutputPath` property and adding the `UseArtifactsOutput` property.

Changes to build configuration:

* Removed the `PackageOutputPath` property from the build configuration to streamline the output path management.

Changes to output management:

* Added the `UseArtifactsOutput` property to enable the use of artifacts output for the build process.