### PR TITLE
Reworked OpenCV <-> TorchSharp conversions to respect the garbage collector

### DIFF
--- a/src/Bonsai.ML.Torch/OpenCVHelper.cs
+++ b/src/Bonsai.ML.Torch/OpenCVHelper.cs
@@ -40,8 +40,9 @@ namespace Bonsai.ML.Torch
 
             IntPtr data = image.ImageData;
             ReadOnlySpan<long> dimensions = stackalloc long[] { height, width, channels };
-            if (data == IntPtr.Zero) 
-                return zeros(dimensions);
+
+            if (data == IntPtr.Zero)
+                throw new InvalidOperationException($"Got {nameof(IplImage)} without backing data, this isn't expected to be possible.");
 
             return TorchSharpEx.CreateTensorFromUnmanagedMemoryWithManagedAnchor(data, image, dimensions, tensorType);
         }
@@ -65,8 +66,9 @@ namespace Bonsai.ML.Torch
 
             IntPtr data = mat.Data;
             ReadOnlySpan<long> dimensions = stackalloc long[] { height, width, channels };
-            if (data == IntPtr.Zero) 
-                return zeros(dimensions);
+
+            if (data == IntPtr.Zero)
+                throw new InvalidOperationException($"Got {nameof(Mat)} without backing data, this isn't expected to be possible.");
 
             return TorchSharpEx.CreateTensorFromUnmanagedMemoryWithManagedAnchor(data, mat, dimensions, tensorType);
         }

--- a/src/Bonsai.ML.Torch/TorchSharpEx.cs
+++ b/src/Bonsai.ML.Torch/TorchSharpEx.cs
@@ -1,0 +1,133 @@
+﻿#nullable enable
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using TorchSharp;
+
+namespace Bonsai.ML.Torch;
+
+internal unsafe static class TorchSharpEx
+{
+    [DllImport("LibTorchSharp")]
+    private static extern IntPtr THSTensor_new(IntPtr rawArray, DeleterCallback deleter, long* dimensions, int numDimensions, sbyte type, sbyte dtype, int deviceType, int deviceIndex, byte requires_grad);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void DeleterCallback(IntPtr context);
+
+    // Torch does not expect the deleter callback to be able to be null since it's a C++ reference and LibTorchSharp does not expose the functions used to create a tensor without a deleter callback, so we must use a no-op callback
+    private static DeleterCallback NullDeleterCallback = _ => { };
+
+    // Acts as GC root for unmanaged callbacks, value is unused
+    private static ConcurrentDictionary<DeleterCallback, nint> ActiveDeleterCallbacks = new();
+
+    /// <summary>Creates a <see cref="torch.Tensor"/> from unmanaged memory that is owned by a managed object</summary>
+    /// <param name="data">The unmanaged memory that will back the tensor, must remain valid and fixed for the lifetime of the tensor</param>
+    /// <param name="managedAnchor">The managed .NET object which owns <paramref name="data"/></param>
+    public static torch.Tensor CreateTensorFromUnmanagedMemoryWithManagedAnchor(IntPtr data, object managedAnchor, ReadOnlySpan<long> dimensions, torch.ScalarType dataType)
+    {
+        //PERF: Ideally this would receive the GCHandle as the context rather than the pointer to the unmanaged memory since that's what we actually want to free
+        // Torch itself has the ability to set the context to something else via `TensorMaker::context(void* value, ContextDeleter deleter)`, but unfortunately this method isn't exposed in LibTorchSharp
+        // This is the inefficient method TorchSharp uses, which has quite a lot of unecessary overhead (particularly the unmanaged delegate allocation.)
+        // Some overhead could be removed by looking up the GCHandle from the native pointer, but doing this without breaking the ability to create redundant tensors over the same data is overly complicated.
+        GCHandle handle = default;
+        DeleterCallback? deleter = null;
+        deleter = (data) =>
+        {
+            if (handle.IsAllocated)
+                handle.Free();
+
+            if (!ActiveDeleterCallbacks.TryRemove(deleter!, out _))
+                Debug.Fail($"The same tensor data handle deleter was called more than once!");
+        };
+
+        if (!ActiveDeleterCallbacks.TryAdd(deleter, default))
+            Debug.Fail("Unreachable");
+
+        handle = GCHandle.Alloc(managedAnchor);
+
+        bool isInitialized = false;
+        try
+        {
+            fixed (long* dimensionsPtr = &dimensions[0])
+            {
+                IntPtr tensorHandle = THSTensor_new(data, deleter, dimensionsPtr, dimensions.Length, (sbyte)dataType, (sbyte)dataType, 0, 0, 0);
+                if (tensorHandle == IntPtr.Zero)
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    tensorHandle = THSTensor_new(data, deleter, dimensionsPtr, dimensions.Length, (sbyte)dataType, (sbyte)dataType, 0, 0, 0);
+                }
+
+                if (tensorHandle == IntPtr.Zero)
+                    torch.CheckForErrors();
+
+                isInitialized = true;
+                return torch.Tensor.UnsafeCreateTensor(tensorHandle);
+            }
+        }
+        finally
+        {
+            if (!isInitialized)
+                deleter(data);
+        }
+    }
+
+    internal readonly ref struct StackTensor
+    {
+        public readonly torch.Tensor Tensor;
+        private readonly object? Anchor;
+
+        internal StackTensor(torch.Tensor tensor, object? anchor)
+        {
+            Tensor = tensor;
+            Anchor = anchor;
+        }
+
+        public void Dispose()
+        {
+            Tensor.Dispose();
+            GC.KeepAlive(Anchor);
+        }
+    }
+
+    /// <summary>Creates a tensor which is associated with a stack scope.</summary>
+    /// <param name="data">The unmanaged memory that will back the tensor, must remain valid and fixed for the lifetime of the tensor</param>
+    /// <param name="managedAnchor">An optional managed .NET object which owns <paramref name="data"/></param>
+    /// <remarks>
+    /// The returned stack tensor must be disposed. The tensor it refers to will not be valid outside of the scope where it was allocated.
+    /// </remarks>
+    internal static StackTensor CreateStackTensor(IntPtr data, object? managedAnchor, ReadOnlySpan<long> dimensions, torch.ScalarType dataType)
+    {
+        fixed (long* dimensionsPtr = &dimensions[0])
+        {
+            IntPtr tensorHandle = THSTensor_new(data, NullDeleterCallback, dimensionsPtr, dimensions.Length, (sbyte)dataType, (sbyte)dataType, 0, 0, 0);
+            if (tensorHandle == IntPtr.Zero)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                tensorHandle = THSTensor_new(data, NullDeleterCallback, dimensionsPtr, dimensions.Length, (sbyte)dataType, (sbyte)dataType, 0, 0, 0);
+            }
+
+            if (tensorHandle == IntPtr.Zero)
+                torch.CheckForErrors();
+
+            torch.Tensor result = torch.Tensor.UnsafeCreateTensor(tensorHandle);
+            return new StackTensor(result, data);
+        }
+    }
+
+    /// <summary>Gets a pointer to the tensor's backing memory</summary>
+    /// <remarks>The data backing a tensor is not necessarily contiguous or even present on the CPU, consider other strategies before using this method.</remarks>
+    public static IntPtr DangerousGetDataPointer(this torch.Tensor tensor)
+    {
+        [DllImport("LibTorchSharp")]
+        static extern IntPtr THSTensor_data(IntPtr handle);
+
+        IntPtr data = THSTensor_data(tensor.Handle);
+        if (data == IntPtr.Zero)
+            torch.CheckForErrors();
+        return data;
+    }
+}


### PR DESCRIPTION
@ncguilbeault I was going to open this against your fork, but it looks like https://github.com/bonsai-rx/machinelearning/pull/48 is actually using this repository as the pull source. (Merging this PR should add its changes to that one.)

I did not test these changes beyond making sure they build. Please make sure everything still works as expected before merging. (These helpers would probably be a good candidate for some unit tests.)

At a high level, the two big changes are:

* For the two `ToTensor` methods, the object used to anchor the data is now the one that owns it. (Previously it was a anchored by a random implicitly-created box)
  * I did not end up trying to avoid the performance penalty of the crummy `deleter` pattern that TorchSharp uses. Torch itself has facilities to do it properly, but LibTorchSharp does not expose them.
  * The unmanaged delegate allocation *could* be avoided, but at the cost of an extreme increase in complexity due to needing to handle cases when someone converts the same data pointer more than once.
  * I left a performance note in case anyone tracks down problems to this spot to save them the research I had to do.
* For `ToImage`/`ToMat`, I reversed things so that the tensor used to copy the source tensor was backed by the new image/mat rather than the other way around as it was previously.
  * In the previous implementation, the memory backing the image/mat was owned by the temporary tensor. This meant that the memory backing the still-alive image/mat would get destroyed when the tensor got garbage collected.
  * This reversal means that exposing `THSTensor_data` is no longer necessary. However on my journey I found that using this method [has some major caveats](https://github.com/pytorch/pytorch/blob/29521256e10816b2287b307621cc2c8cb3fdf032/c10/core/TensorImpl.h#L1620-L1629) which make it dangerous to use unless you really dot your T's and cross your I's. As such I left the unused stub as a warning marker to anyone else who is tempted to use it.

I'll leave a few self-review comments to clarify things, but feel free to ping me on Teams when I'm up tomorrow if you have any questions.