### PR TITLE
Add meta-package for installing libtorch-cpu

### DIFF
--- a/Bonsai.ML.sln
+++ b/Bonsai.ML.sln
@@ -26,6 +26,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.ML.PointProcessDecod
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.ML.PointProcessDecoder.Design", "src\Bonsai.ML.PointProcessDecoder.Design\Bonsai.ML.PointProcessDecoder.Design.csproj", "{91C3E252-9457-43AB-A21A-6064E2404BAA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.ML.Torch-cpu", "src\Bonsai.ML.Torch-cpu\Bonsai.ML.Torch-cpu.csproj", "{6FB774A6-0165-4576-A6A9-5E0CC17CB633}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{DEE5DD87-39C1-BF34-B639-A387DCCF972B}"
 	ProjectSection(SolutionItems) = preProject
 		build\Common.csproj.props = build\Common.csproj.props
@@ -90,6 +92,10 @@ Global
 		{91C3E252-9457-43AB-A21A-6064E2404BAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{91C3E252-9457-43AB-A21A-6064E2404BAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{91C3E252-9457-43AB-A21A-6064E2404BAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FB774A6-0165-4576-A6A9-5E0CC17CB633}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FB774A6-0165-4576-A6A9-5E0CC17CB633}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FB774A6-0165-4576-A6A9-5E0CC17CB633}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FB774A6-0165-4576-A6A9-5E0CC17CB633}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/articles/Torch/torch-overview.md
+++ b/docs/articles/Torch/torch-overview.md
@@ -4,10 +4,10 @@ The Torch package provides a Bonsai interface to interact with [TorchSharp](http
 
 ## Installation Guide
 
-The Bonsai.ML.Torch package can be installed through the Bonsai Package Manager and depends on the TorchSharp library. Additionally, running the package requires installing the specific torch DLLs needed for your desired application. The steps for installing are outlined below.
+The `Bonsai.ML.Torch` package can be installed through the Bonsai package manager and depends on the `TorchSharp` library. Additionally, running the package requires installing the specific torch DLLs needed for your desired application. The steps for installing these are outlined below.
 
 ### Running on the CPU 
-For running the package using the CPU, the `TorchSharp-cpu` library should be installed through the NuGet package manager.
+The `Bonsai.ML.Torch-cpu` library should only be installed if you are looking to run on the CPU only. You should not install the `Bonsai.ML.Torch-cpu` package if you plan to run a CUDA-compatible GPU device. For GPU support, you should follow the instructions outlined in the [next section](#running-on-the-gpu).
 
 ### Running on the GPU
 To run torch on the GPU, you first need to ensure that you have a CUDA compatible device installed on your system. 
@@ -16,7 +16,7 @@ Next, you must follow the [CUDA installation guide for Windows](https://docs.nvi
 
 Next, you need to install the `cuDNN v9` library following the [guide for Windows](https://docs.nvidia.com/deeplearning/cudnn/latest/installation/windows.html) or the [guide for Linux](https://docs.nvidia.com/deeplearning/cudnn/latest/installation/linux.html). Again, you need to ensure you have the correct version installed (v9). You should consult [nvidia's support matrix](https://docs.nvidia.com/deeplearning/cudnn/latest/reference/support-matrix.html) to ensure the versions of CUDA and cuDNN you installed are compatible with your specific OS, graphics driver, and hardware.
 
-Once complete, you need to install the cuda-compatible torch libraries and place them into the correct location. You can download the libraries from [the PyTorch website](https://pytorch.org/get-started/locally/) with the following options selected:
+Once complete, you need to install the CUDA-compatible torch libraries and place them into the correct location. You can download the libraries from [the PyTorch website](https://pytorch.org/get-started/locally/) with the following options selected:
 
 - PyTorch Build: Stable (2.5.1)
 - OS: [Your OS]

--- a/src/Bonsai.ML.Torch-cpu/Bonsai.ML.Torch-cpu.csproj
+++ b/src/Bonsai.ML.Torch-cpu/Bonsai.ML.Torch-cpu.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Title>Bonsai.ML.Torch-cpu</Title>
+    <Description>A Bonsai package for TorchSharp tensor manipulations. This package combines the Bonsai.ML.Torch package with LibTorch 2.5.1 CPU support.</Description>
+    <PackageTags>$(PackageTags) Torch Tensor cpu</PackageTags>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+
+    <!--
+    This warning happens because this package has no assemblies but does have dependencies
+    https://github.com/NuGet/Home/issues/8583
+    -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="libtorch-cpu" Version="2.5.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Bonsai.ML.Torch\Bonsai.ML.Torch.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
To ensure architecture dependencies are easy to resolve from the package manager, we introduce here a meta-package tagged with `BonsaiLibrary` (to ensure correct filtering) and referencing `libtorch-cpu`. We follow the TorchSharp convention of tagging the package id with the native suffix separated with hyphen.