### PR TITLE
Restore missing element icon during packaging

### DIFF
--- a/build/Project.csproj.props
+++ b/build/Project.csproj.props
@@ -1,4 +1,9 @@
 <Project>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)../elementIcon.svg" >
+      <LogicalName>$(RootNamespace).$(MSBuildProjectName).svg</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
   <PropertyGroup>
     <Nullable>annotations</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This PR restores the functionality of correctly packing the elementIcon.svg with individual packages using the correct naming. This was accidentally removed in https://github.com/bonsai-rx/machinelearning/pull/56