### PR TITLE
Explicitly create ToolStripItem array in call to ToolStripContainer.Items.AddRange

### DIFF
--- a/src/Bonsai.ML.PointProcessDecoder.Design/DensityEstimationsVisualizer.cs
+++ b/src/Bonsai.ML.PointProcessDecoder.Design/DensityEstimationsVisualizer.cs
@@ -347,8 +347,8 @@ namespace Bonsai.ML.PointProcessDecoder.Design
                 Visible = true,
             };
 
-            _statusStrip.Items.AddRange([
-                pageIndexLabel, 
+            _statusStrip.Items.AddRange(new ToolStripItem[] {
+                pageIndexLabel,
                 _pageIndexControl,
                 rowLabel,
                 _rowControl,
@@ -356,7 +356,7 @@ namespace Bonsai.ML.PointProcessDecoder.Design
                 _columnControl,
                 _displaySelectedButton,
                 _resetSelectedButton
-            ]);
+            });
 
             var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
             visualizerService?.AddControl(_container);

--- a/src/Bonsai.ML.PointProcessDecoder.Design/IntensitiesVisualizer.cs
+++ b/src/Bonsai.ML.PointProcessDecoder.Design/IntensitiesVisualizer.cs
@@ -324,8 +324,8 @@ namespace Bonsai.ML.PointProcessDecoder.Design
                 Visible = true,
             };
 
-            _statusStrip.Items.AddRange([
-                pageIndexLabel, 
+            _statusStrip.Items.AddRange(new ToolStripItem[] {
+                pageIndexLabel,
                 _pageIndexControl,
                 rowLabel,
                 _rowControl,
@@ -333,7 +333,7 @@ namespace Bonsai.ML.PointProcessDecoder.Design
                 _columnControl,
                 _displaySelectedButton,
                 _resetSelectedButton
-            ]);
+            });
 
             var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
             visualizerService?.AddControl(_container);

--- a/src/Bonsai.ML.PointProcessDecoder.Design/LikelihoodVisualizer.cs
+++ b/src/Bonsai.ML.PointProcessDecoder.Design/LikelihoodVisualizer.cs
@@ -125,10 +125,10 @@ namespace Bonsai.ML.PointProcessDecoder.Design
                 }
             };
 
-            Plot.VisualizerPropertiesDropDown.DropDownItems.AddRange([
+            Plot.VisualizerPropertiesDropDown.DropDownItems.AddRange(new ToolStripItem[] {
                 capacityLabel,
                 capacityValue
-            ]);
+            });
 
             Plot.View.HandleDestroyed += (sender, e) =>
             {

--- a/src/Bonsai.ML.PointProcessDecoder.Design/PosteriorVisualizer.cs
+++ b/src/Bonsai.ML.PointProcessDecoder.Design/PosteriorVisualizer.cs
@@ -130,10 +130,10 @@ namespace Bonsai.ML.PointProcessDecoder.Design
                 }
             };
 
-            Plot.VisualizerPropertiesDropDown.DropDownItems.AddRange([
+            Plot.VisualizerPropertiesDropDown.DropDownItems.AddRange(new ToolStripItem[] {
                 capacityLabel,
                 capacityValue
-            ]);
+            });
 
             Plot.View.HandleDestroyed += (sender, e) =>
             {

--- a/src/Bonsai.ML.PointProcessDecoder.Design/SelectUnitIdsVisualizer.cs
+++ b/src/Bonsai.ML.PointProcessDecoder.Design/SelectUnitIdsVisualizer.cs
@@ -308,8 +308,8 @@ namespace Bonsai.ML.PointProcessDecoder.Design
                 Visible = true,
             };
 
-            _statusStrip.Items.AddRange([
-                pageIndexLabel, 
+            _statusStrip.Items.AddRange(new ToolStripItem[] {
+                pageIndexLabel,
                 _pageIndexControl,
                 rowLabel,
                 _rowControl,
@@ -317,7 +317,7 @@ namespace Bonsai.ML.PointProcessDecoder.Design
                 _columnControl,
                 _displaySelectedButton,
                 _resetSelectedButton
-            ]);
+            });
 
             var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
             visualizerService?.AddControl(_container);


### PR DESCRIPTION
This PR changes how the visualizers in the `PointProcessDecoder.Design` add items to the ToolStripContainer. Previously, the call to ToolStripContainer.Items.AddRange() relied on a collection expression to pass in the ToolStripItem objects as an argument parameter. However, on certain versions of the compiler, this will cause an error to be thrown on build, stating the call to `ToolStripContainer.Items.AddRange()` is ambiguous ToolStripItem[] and ToolStripItemCollection. This PR fixes this issue.