### PR TITLE
Align tensor shape with image shape using element size

### DIFF
--- a/src/Bonsai.ML.Torch/OpenCVHelper.cs
+++ b/src/Bonsai.ML.Torch/OpenCVHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenCV.Net;
+using TorchSharp;
 using static TorchSharp.torch;
 
 namespace Bonsai.ML.Torch
@@ -32,12 +33,14 @@ namespace Bonsai.ML.Torch
             if (image == null)
                 return empty([ 0, 0, 0 ]);
 
-            int height = image.Height;
-            int channels = image.Channels;
-            var width = image.WidthStep / channels;
-
             var iplDepth = image.Depth;
             var tensorType = bitDepthLookup.FirstOrDefault(x => x.Value.IplDepth == iplDepth).Key;
+
+            int height = image.Height;
+            int channels = image.Channels;
+            int elementSize = tensorType.ElementSize();
+            int stride = image.WidthStep / elementSize;
+            var width = stride / channels;
 
             IntPtr data = image.ImageData;
             ReadOnlySpan<long> dimensions = stackalloc long[] { height, width, channels };


### PR DESCRIPTION
This PR fixes how the `ToTensor` method in the `Bonsai.ML.Torch` package computes the width of a tensor converted from an `IplImage`. Previously, the width was derived by dividing `WidthStep` by the number of channels. However, since `WidthStep` is the row stride in bytes, this calculation is only correct for images with 1-byte element types (`U8`/`S8`). For images with wider element types (`S16`, `S32`, `F32`, `F64`), the computed width was inflated by the element size in bytes, producing a tensor with an incorrect shape that describes more memory than the underlying image buffer actually contains.

This PR changes the calculation to first convert the byte stride into an element stride, by dividing `WidthStep` by the element size of the input image data type, before dividing by the number of channels. The tensor dimensions are now correctly mapped to the image's data for all supported bit depths, and the resulting tensor no longer overruns the backing buffer. 

Fixes #88.
